### PR TITLE
Temporary using std::string

### DIFF
--- a/alica_engine/include/engine/BasicBehaviour.h
+++ b/alica_engine/include/engine/BasicBehaviour.h
@@ -18,6 +18,9 @@ class ITrigger;
 
 namespace alica
 {
+// TODO: get rid of this line once generator templates get an overhaul
+using std::string;
+
 class Variable;
 class RunningPlan;
 


### PR DESCRIPTION
When DomainBehaviour.cpp is generated into the Expression Validators directory by the plan designer, the constructor argument is missing the `std::` namespace, which causes the compiler to throw an error because of the previously removed instances of `using namespace std`.