### PR TITLE
Cleanup system config caching

### DIFF
--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -5,9 +5,9 @@
 #include "engine/constraintmodul/ISolver.h"
 
 #include <SystemConfig.h>
+#include <essentials/AgentIDManager.h>
 #include <list>
 #include <string>
-#include <essentials/AgentIDManager.h>
 
 #include <unordered_map>
 
@@ -158,7 +158,6 @@ private:
 
     const Plan* masterPlan;
     std::unordered_map<size_t, ISolverBase*> _solvers;
-    essentials::SystemConfig* sc;
 };
 
 /**

--- a/alica_engine/include/engine/parser/PlanParser.h
+++ b/alica_engine/include/engine/parser/PlanParser.h
@@ -44,7 +44,6 @@ public:
     int64_t parserId(tinyxml2::XMLElement* node);
 
 private:
-    essentials::SystemConfig* sc;
     std::shared_ptr<ModelFactory> mf;
     PlanRepository* rep;
     Plan* masterPlan;
@@ -53,7 +52,6 @@ private:
     std::string basePlanPath;
     std::string baseRolePath;
     std::string currentDirectory;
-    std::string domainConfigFolder;
     std::string currentFile;
     void parseTaskFile(const std::string& currentFile);
     void parseRoleDefFile(const std::string& currentFile);

--- a/alica_engine/include/engine/parser/PlanWriter.h
+++ b/alica_engine/include/engine/parser/PlanWriter.h
@@ -38,12 +38,11 @@ class AlicaEngine;
  */
 class PlanWriter
 {
-  public:
+public:
     PlanWriter(AlicaEngine* ae, PlanRepository* rep);
     ~PlanWriter();
 
     const std::string& getTempPlanDir() const;
-    const std::string& getConfigPath() const;
     const AlicaElementGrp& getPlansToSave() const;
 
     void saveAllPlans();
@@ -61,7 +60,7 @@ class PlanWriter
     tinyxml2::XMLDocument* createRoleSetXMLDocument(const RoleSet* r);
     tinyxml2::XMLDocument* createTaskRepositoryXMLDocument(const TaskRepository* tr);
 
-  private:
+private:
     PlanRepository* rep;
     std::string currentFile;
     static int objectCounter;
@@ -84,10 +83,9 @@ class PlanWriter
     tinyxml2::XMLElement* createTransitionXMLNode(const Transition* t, tinyxml2::XMLDocument* doc);
     tinyxml2::XMLElement* createEntryPointXMLNode(const EntryPoint* e, tinyxml2::XMLDocument* doc);
 
-  protected:
+protected:
     AlicaEngine* ae;
     std::string tempPlanDir;
-    std::string configPath;
     AlicaElementGrp plansToSave;
     AlicaElementGrp plansSaved;
 };

--- a/alica_engine/include/engine/teammanager/TeamManager.h
+++ b/alica_engine/include/engine/teammanager/TeamManager.h
@@ -60,7 +60,7 @@ private:
     AgentMap _agents;
     bool useConfigForTeam;
 
-    void readTeamFromConfig(essentials::SystemConfig* sc);
+    void readTeamFromConfig();
 };
 
 class ActiveAgentBaseIterator : public std::iterator<std::forward_iterator_tag, AgentIDConstPtr>

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -43,7 +43,6 @@ AlicaEngine::AlicaEngine(essentials::AgentIDManager* idManager, const std::strin
         , planBase(nullptr)
         , communicator(nullptr)
         , alicaClock(nullptr)
-        , sc(essentials::SystemConfig::getInstance())
         , terminating(false)
         , expressionHandler(nullptr)
         , log(nullptr)
@@ -52,9 +51,10 @@ AlicaEngine::AlicaEngine(essentials::AgentIDManager* idManager, const std::strin
         , stepEngine(stepEngine)
         , agentIDManager(idManager)
 {
-    _maySendMessages = !(*sc)["Alica"]->get<bool>("Alica.SilentStart", NULL);
-    this->useStaticRoles = (*sc)["Alica"]->get<bool>("Alica.UseStaticRoles", NULL);
-    PartialAssignment::allowIdling((*this->sc)["Alica"]->get<bool>("Alica.AllowIdling", NULL));
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    _maySendMessages = !sc["Alica"]->get<bool>("Alica.SilentStart", NULL);
+    this->useStaticRoles = sc["Alica"]->get<bool>("Alica.UseStaticRoles", NULL);
+    PartialAssignment::allowIdling(sc["Alica"]->get<bool>("Alica.AllowIdling", NULL));
 
     this->planRepository = new PlanRepository();
     this->planParser = new PlanParser(this->planRepository);
@@ -273,7 +273,7 @@ void AlicaEngine::setStepEngine(bool stepEngine)
  */
 std::string AlicaEngine::getRobotName() const
 {
-    return sc->getHostname();
+    return essentials::SystemConfig::getInstance().getHostname();
 }
 
 void AlicaEngine::setLog(Logger* log)

--- a/alica_engine/src/engine/Logger.cpp
+++ b/alica_engine/src/engine/Logger.cpp
@@ -32,11 +32,11 @@ Logger::Logger(AlicaEngine* ae)
         , receivedEvent(false)
         , _fileWriter()
 {
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
-    _active = (*sc)["Alica"]->get<bool>("Alica.EventLogging.Enabled", NULL);
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    _active = sc["Alica"]->get<bool>("Alica.EventLogging.Enabled", NULL);
     if (_active) {
         std::string robotName = ae->getRobotName();
-        std::string logPath = (*sc)["Alica"]->get<std::string>("Alica.EventLogging.LogFolder", NULL);
+        std::string logPath = sc["Alica"]->get<std::string>("Alica.EventLogging.LogFolder", NULL);
         if (!essentials::FileSystem::isDirectory(logPath)) {
             if (!essentials::FileSystem::createDirectory(logPath, 0777)) {
                 AlicaEngine::abort("Cannot create log folder: ", logPath);

--- a/alica_engine/src/engine/PlanBase.cpp
+++ b/alica_engine/src/engine/PlanBase.cpp
@@ -47,11 +47,11 @@ PlanBase::PlanBase(AlicaEngine* ae, const Plan* masterPlan)
         , _isWaiting(false)
 
 {
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
 
-    double freq = (*sc)["Alica"]->get<double>("Alica.EngineFrequency", NULL);
-    double minbcfreq = (*sc)["Alica"]->get<double>("Alica.MinBroadcastFrequency", NULL);
-    double maxbcfreq = (*sc)["Alica"]->get<double>("Alica.MaxBroadcastFrequency", NULL);
+    double freq = sc["Alica"]->get<double>("Alica.EngineFrequency", NULL);
+    double minbcfreq = sc["Alica"]->get<double>("Alica.MinBroadcastFrequency", NULL);
+    double maxbcfreq = sc["Alica"]->get<double>("Alica.MaxBroadcastFrequency", NULL);
 
     if (freq > 1000) {
         AlicaEngine::abort("PB: ALICA should not be used with more than 1000Hz");
@@ -71,9 +71,9 @@ PlanBase::PlanBase(AlicaEngine* ae, const Plan* masterPlan)
 
     AlicaTime halfLoopTime = _loopTime / 2;
 
-    _sendStatusMessages = (*sc)["Alica"]->get<bool>("Alica.StatusMessages.Enabled", NULL);
+    _sendStatusMessages = sc["Alica"]->get<bool>("Alica.StatusMessages.Enabled", NULL);
     if (_sendStatusMessages) {
-        double stfreq = (*sc)["Alica"]->get<double>("Alica.StatusMessages.Frequency", NULL);
+        double stfreq = sc["Alica"]->get<double>("Alica.StatusMessages.Frequency", NULL);
         if (stfreq > freq) {
             AlicaEngine::abort("PB: Alica.conf: Status messages frequency must not exceed the engine frequency");
         }

--- a/alica_engine/src/engine/RuleBook.cpp
+++ b/alica_engine/src/engine/RuleBook.cpp
@@ -37,8 +37,8 @@ RuleBook::RuleBook(AlicaEngine* ae, PlanBase* pb)
         , _log(ae->getLog())
         , _changeOccurred(true)
 {
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
-    _maxConsecutiveChanges = (*sc)["Alica"]->get<int>("Alica.MaxRuleApplications", NULL);
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    _maxConsecutiveChanges = sc["Alica"]->get<int>("Alica.MaxRuleApplications", NULL);
     assert(_to && _tm && _ps && _pb && _sm && _log);
 }
 

--- a/alica_engine/src/engine/RunningPlan.cpp
+++ b/alica_engine/src/engine/RunningPlan.cpp
@@ -41,7 +41,7 @@ AlicaTime RunningPlan::assignmentProtectionTime = AlicaTime::zero();
 void RunningPlan::init()
 {
     assignmentProtectionTime =
-            AlicaTime::milliseconds((*essentials::SystemConfig::getInstance())["Alica"]->get<unsigned long>("Alica.AssignmentProtectionTime", NULL));
+            AlicaTime::milliseconds((essentials::SystemConfig::getInstance())["Alica"]->get<unsigned long>("Alica.AssignmentProtectionTime", NULL));
 }
 
 RunningPlan::RunningPlan(AlicaEngine* ae)

--- a/alica_engine/src/engine/allocationauthority/CycleManager.cpp
+++ b/alica_engine/src/engine/allocationauthority/CycleManager.cpp
@@ -35,17 +35,17 @@ CycleManager::CycleManager(AlicaEngine* ae, RunningPlan* p)
         , _fixedAllocation()
         , _newestAllocationDifference(0)
 {
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
-    maxAllocationCycles = (*sc)["Alica"]->get<int>("Alica", "CycleDetection", "CycleCount", NULL);
-    enabled = (*sc)["Alica"]->get<bool>("Alica", "CycleDetection", "Enabled", NULL);
-    minimalOverrideTimeInterval = AlicaTime::milliseconds((*sc)["Alica"]->get<unsigned long>("Alica", "CycleDetection", "MinimalAuthorityTimeInterval", NULL));
-    maximalOverrideTimeInterval = AlicaTime::milliseconds((*sc)["Alica"]->get<unsigned long>("Alica", "CycleDetection", "MaximalAuthorityTimeInterval", NULL));
-    overrideShoutInterval = AlicaTime::milliseconds((*sc)["Alica"]->get<unsigned long>("Alica", "CycleDetection", "MessageTimeInterval", NULL));
-    overrideWaitInterval = AlicaTime::milliseconds((*sc)["Alica"]->get<unsigned long>("Alica", "CycleDetection", "MessageWaitTimeInterval", NULL));
-    int historySize = (*sc)["Alica"]->get<int>("Alica", "CycleDetection", "HistorySize", NULL);
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    maxAllocationCycles = sc["Alica"]->get<int>("Alica", "CycleDetection", "CycleCount", NULL);
+    enabled = sc["Alica"]->get<bool>("Alica", "CycleDetection", "Enabled", NULL);
+    minimalOverrideTimeInterval = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica", "CycleDetection", "MinimalAuthorityTimeInterval", NULL));
+    maximalOverrideTimeInterval = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica", "CycleDetection", "MaximalAuthorityTimeInterval", NULL));
+    overrideShoutInterval = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica", "CycleDetection", "MessageTimeInterval", NULL));
+    overrideWaitInterval = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica", "CycleDetection", "MessageWaitTimeInterval", NULL));
+    int historySize = sc["Alica"]->get<int>("Alica", "CycleDetection", "HistorySize", NULL);
 
-    this->intervalIncFactor = (*sc)["Alica"]->get<double>("Alica", "CycleDetection", "IntervalIncreaseFactor", NULL);
-    this->intervalDecFactor = (*sc)["Alica"]->get<double>("Alica", "CycleDetection", "IntervalDecreaseFactor", NULL);
+    this->intervalIncFactor = sc["Alica"]->get<double>("Alica", "CycleDetection", "IntervalIncreaseFactor", NULL);
+    this->intervalDecFactor = sc["Alica"]->get<double>("Alica", "CycleDetection", "IntervalDecreaseFactor", NULL);
 
     _allocationHistory.resize(historySize);
 

--- a/alica_engine/src/engine/collections/RobotProperties.cpp
+++ b/alica_engine/src/engine/collections/RobotProperties.cpp
@@ -18,15 +18,15 @@ RobotProperties::RobotProperties(const AlicaEngine* engine, const std::string& n
  */
 void RobotProperties::readFromConfig(const AlicaEngine* engine, const std::string& name)
 {
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
 
-    std::shared_ptr<std::vector<std::string>> caps = (*sc)["Globals"]->getNames("Globals", "Team", name.c_str(), NULL);
+    std::shared_ptr<std::vector<std::string>> caps = sc["Globals"]->getNames("Globals", "Team", name.c_str(), NULL);
     for (const std::string& s : *caps) {
         if (s.compare("ID") == 0 || s.compare("DefaultRole") == 0) {
             continue;
         }
         std::string key = s;
-        std::string kvalue = (*sc)["Globals"]->get<std::string>("Globals", "Team", name.c_str(), s.c_str(), NULL);
+        std::string kvalue = sc["Globals"]->get<std::string>("Globals", "Team", name.c_str(), s.c_str(), NULL);
         for (const Capability* cap : engine->getPlanRepository()->getCapabilities()) {
             if (cap->getName().compare(key) == 0) {
                 for (const CapValue* val : cap->getCapValues()) {
@@ -38,7 +38,7 @@ void RobotProperties::readFromConfig(const AlicaEngine* engine, const std::strin
             }
         }
     }
-    _defaultRole = (*sc)["Globals"]->tryGet<std::string>("NOROLESPECIFIED", "Globals", "Team", name.c_str(), "DefaultRole", NULL);
+    _defaultRole = sc["Globals"]->tryGet<std::string>("NOROLESPECIFIED", "Globals", "Team", name.c_str(), "DefaultRole", NULL);
 }
 
 RobotProperties::~RobotProperties() {}

--- a/alica_engine/src/engine/constraintmodul/VariableSyncModule.cpp
+++ b/alica_engine/src/engine/constraintmodul/VariableSyncModule.cpp
@@ -15,14 +15,14 @@
 namespace alica
 {
 VariableSyncModule::VariableSyncModule(AlicaEngine* ae)
-    : _ae(ae)
-    , _running(false)
-    , _timer(nullptr)
-    , _distThreshold(0)
-    , _communicator(nullptr)
-    , _ttl4Communication(AlicaTime::zero())
-    , _ttl4Usage(AlicaTime::zero())
-    , _ownResults(nullptr)
+        : _ae(ae)
+        , _running(false)
+        , _timer(nullptr)
+        , _distThreshold(0)
+        , _communicator(nullptr)
+        , _ttl4Communication(AlicaTime::zero())
+        , _ttl4Usage(AlicaTime::zero())
+        , _ownResults(nullptr)
 {
 }
 
@@ -38,11 +38,11 @@ void VariableSyncModule::init()
         return;
     }
     _running = true;
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
-    bool communicationEnabled = (*sc)["Alica"]->get<bool>("Alica", "CSPSolving", "EnableCommunication", NULL);
-    _ttl4Communication = AlicaTime::milliseconds((*sc)["Alica"]->get<long>("Alica", "CSPSolving", "SeedTTL4Communication", NULL));
-    _ttl4Usage = AlicaTime::milliseconds((*sc)["Alica"]->get<long>("Alica", "CSPSolving", "SeedTTL4Usage", NULL));
-    _distThreshold = (*sc)["Alica"]->get<double>("Alica", "CSPSolving", "SeedMergingThreshold", NULL);
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    bool communicationEnabled = sc["Alica"]->get<bool>("Alica", "CSPSolving", "EnableCommunication", NULL);
+    _ttl4Communication = AlicaTime::milliseconds(sc["Alica"]->get<long>("Alica", "CSPSolving", "SeedTTL4Communication", NULL));
+    _ttl4Usage = AlicaTime::milliseconds(sc["Alica"]->get<long>("Alica", "CSPSolving", "SeedTTL4Usage", NULL));
+    _distThreshold = sc["Alica"]->get<double>("Alica", "CSPSolving", "SeedMergingThreshold", NULL);
 
     AgentIDConstPtr ownId = _ae->getTeamManager()->getLocalAgentID();
     {
@@ -55,7 +55,7 @@ void VariableSyncModule::init()
 
     if (communicationEnabled) {
         _communicator = _ae->getCommunicator();
-        double communicationFrequency = (*sc)["Alica"]->get<double>("Alica", "CSPSolving", "CommunicationFrequency", NULL);
+        double communicationFrequency = sc["Alica"]->get<double>("Alica", "CSPSolving", "CommunicationFrequency", NULL);
         AlicaTime interval = AlicaTime::seconds(1.0 / communicationFrequency);
         if (_timer == nullptr) {
             _timer = new essentials::NotifyTimer<VariableSyncModule>(interval.inMilliseconds(), &VariableSyncModule::publishContent, this);
@@ -99,10 +99,8 @@ void VariableSyncModule::onSolverResult(const SolverResult& msg)
     if (re == nullptr) {
         std::unique_ptr<ResultEntry> new_entry(new ResultEntry(msg.senderID));
         std::lock_guard<std::mutex> lock(_mutex);
-        auto agent_sorted_loc = std::upper_bound(_store.begin(), _store.end(), new_entry, 
-            [](const std::unique_ptr<ResultEntry>& a, const std::unique_ptr<ResultEntry>& b) {
-                return (a->getId() < b->getId());
-            });
+        auto agent_sorted_loc = std::upper_bound(_store.begin(), _store.end(), new_entry,
+                [](const std::unique_ptr<ResultEntry>& a, const std::unique_ptr<ResultEntry>& b) { return (a->getId() < b->getId()); });
         agent_sorted_loc = _store.insert(agent_sorted_loc, std::move(new_entry));
         re = (*agent_sorted_loc).get();
     }
@@ -139,10 +137,10 @@ void VariableSyncModule::postResult(int64_t vid, Variant result)
 }
 
 VariableSyncModule::VotedSeed::VotedSeed(std::vector<Variant>&& vs)
-    : _values(std::move(vs))
-    , _supporterCount(_values.size())
-    , _hash(0)
-    , _totalSupCount(0)
+        : _values(std::move(vs))
+        , _supporterCount(_values.size())
+        , _hash(0)
+        , _totalSupCount(0)
 {
     assert(_values.size() == _supporterCount.size());
     for (const Variant& v : _values) {
@@ -153,10 +151,10 @@ VariableSyncModule::VotedSeed::VotedSeed(std::vector<Variant>&& vs)
 }
 
 VariableSyncModule::VotedSeed::VotedSeed(VotedSeed&& o)
-    : _values(std::move(o._values))
-    , _supporterCount(std::move(o._supporterCount))
-    , _hash(o._hash)
-    , _totalSupCount(o._totalSupCount)
+        : _values(std::move(o._values))
+        , _supporterCount(std::move(o._supporterCount))
+        , _hash(o._hash)
+        , _totalSupCount(o._totalSupCount)
 {
 }
 

--- a/alica_engine/src/engine/model/AbstractPlan.cpp
+++ b/alica_engine/src/engine/model/AbstractPlan.cpp
@@ -20,8 +20,8 @@ AbstractPlan::AbstractPlan()
         , _runtimeCondition(nullptr)
 
 {
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
-    _authorityTimeInterval = AlicaTime::milliseconds((*sc)["Alica"]->get<unsigned long>("Alica", "CycleDetection", "MinimalAuthorityTimeInterval", NULL));
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    _authorityTimeInterval = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica", "CycleDetection", "MinimalAuthorityTimeInterval", NULL));
 }
 
 AbstractPlan::AbstractPlan(int64_t id)
@@ -30,8 +30,8 @@ AbstractPlan::AbstractPlan(int64_t id)
         , _preCondition(nullptr)
         , _runtimeCondition(nullptr)
 {
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
-    _authorityTimeInterval = AlicaTime::milliseconds((*sc)["Alica"]->get<unsigned long>("Alica", "CycleDetection", "MinimalAuthorityTimeInterval", NULL));
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    _authorityTimeInterval = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica", "CycleDetection", "MinimalAuthorityTimeInterval", NULL));
 }
 
 AbstractPlan::~AbstractPlan() {}

--- a/alica_engine/src/engine/parser/PlanParser.cpp
+++ b/alica_engine/src/engine/parser/PlanParser.cpp
@@ -20,17 +20,17 @@ PlanParser::PlanParser(PlanRepository* rep)
     this->masterPlan = nullptr;
     this->rep = rep;
     this->mf = shared_ptr<ModelFactory>(new ModelFactory(this, rep));
-    this->sc = essentials::SystemConfig::getInstance();
-    this->domainConfigFolder = this->sc->getConfigPath();
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    std::string domainConfigFolder = sc.getConfigPath();
 
     try {
-        this->planDir = (*this->sc)["Alica"]->get<string>("Alica.PlanDir", NULL);
+        this->planDir = sc["Alica"]->get<string>("Alica.PlanDir", NULL);
     } catch (const std::runtime_error& error) {
         AlicaEngine::abort("PP: Plan Directory does not exist.\n", error.what());
     }
 
     try {
-        this->roleDir = (*this->sc)["Alica"]->get<string>("Alica.RoleDir", NULL);
+        this->roleDir = sc["Alica"]->get<string>("Alica.RoleDir", NULL);
     } catch (const std::runtime_error& error) {
         AlicaEngine::abort("PP: Role Directory does not exist.\n", error.what());
     }

--- a/alica_engine/src/engine/parser/PlanWriter.cpp
+++ b/alica_engine/src/engine/parser/PlanWriter.cpp
@@ -51,11 +51,9 @@ int PlanWriter::objectCounter = 0;
 PlanWriter::PlanWriter(AlicaEngine* ae, PlanRepository* rep)
 {
     this->ae = ae;
-    string path = essentials::SystemConfig::getInstance()->getConfigPath();
+    string path = essentials::SystemConfig::getInstance().getConfigPath();
     this->tempPlanDir = essentials::FileSystem::combinePaths(path, "plans/tmp/");
     this->rep = rep;
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
-    this->configPath = sc->getConfigPath();
 }
 
 PlanWriter::~PlanWriter() {}
@@ -70,11 +68,6 @@ const std::string& PlanWriter::getTempPlanDir() const
 void PlanWriter::setTempPlanDir(const std::string& directory)
 {
     this->tempPlanDir = directory;
-}
-
-const std::string& PlanWriter::getConfigPath() const
-{
-    return configPath;
 }
 
 /**
@@ -546,21 +539,22 @@ std::string PlanWriter::getRelativeFileName(const std::string& file)
     if (essentials::FileSystem::isPathRooted(file)) {
         ufile = file;
     } else {
+        essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+        std::string configPath = sc.getConfigPath();
         if (file.substr(file.size() - 4, 4) == ".beh" || file.substr(file.size() - 4, 4) == ".pty" || file.substr(file.size() - 4, 4) == ".pml" ||
                 file.substr(file.size() - 3, 3) == ".pp") {
-            essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
-            std::string tfile = (*sc)["Alica"]->get<string>("Alica.PlanDir", NULL);
+
+            std::string tfile = sc["Alica"]->get<string>("Alica.PlanDir", NULL);
             // tfile = essentials::FileSystem::combinePaths(tfile, file);
             if (!essentials::FileSystem::isPathRooted(tfile)) {
-                tfile = essentials::FileSystem::combinePaths(this->configPath, tfile);
+                tfile = essentials::FileSystem::combinePaths(configPath, tfile);
             }
             ufile = tfile;
         } else if (file.substr(file.size() - 4, 4) == ".tsk") {
-            essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
-            std::string tfile = (*sc)["Alica"]->get<string>("Alica.MiscDir", NULL);
+            std::string tfile = sc["Alica"]->get<string>("Alica.MiscDir", NULL);
             // tfile = essentials::FileSystem::combinePaths(tfile, file);
             if (!essentials::FileSystem::isPathRooted(tfile)) {
-                tfile = essentials::FileSystem::combinePaths(this->configPath, tfile);
+                tfile = essentials::FileSystem::combinePaths(configPath, tfile);
             }
             ufile = tfile;
         } else {

--- a/alica_engine/src/engine/teammanager/TeamManager.cpp
+++ b/alica_engine/src/engine/teammanager/TeamManager.cpp
@@ -27,23 +27,24 @@ TeamManager::~TeamManager()
 
 void TeamManager::init()
 {
-    essentials::SystemConfig* sc =essentials::SystemConfig::getInstance();
-    this->teamTimeOut = AlicaTime::milliseconds((*sc)["Alica"]->get<unsigned long>("Alica.TeamTimeOut", NULL));
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    this->teamTimeOut = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica.TeamTimeOut", NULL));
 
     if (useConfigForTeam) {
-        this->readTeamFromConfig(sc);
+        this->readTeamFromConfig();
     }
 }
 
-void TeamManager::readTeamFromConfig(essentials::SystemConfig* sc)
+void TeamManager::readTeamFromConfig()
 {
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     std::string localAgentName = this->engine->getRobotName();
-    std::shared_ptr<std::vector<std::string>> agentNames = (*sc)["Globals"]->getSections("Globals.Team", NULL);
+    std::shared_ptr<std::vector<std::string>> agentNames = sc["Globals"]->getSections("Globals.Team", NULL);
 
     Agent* agent;
     bool foundSelf = false;
     for (const std::string& agentName : *agentNames) {
-        int id = (*sc)["Globals"]->tryGet<int>(-1, "Globals", "Team", agentName.c_str(), "ID", NULL);
+        int id = sc["Globals"]->tryGet<int>(-1, "Globals", "Team", agentName.c_str(), "ID", NULL);
 
         agent = new Agent(this->engine, this->teamTimeOut, this->engine->getId(id), agentName);
         if (!foundSelf && agentName.compare(localAgentName) == 0) {
@@ -63,7 +64,7 @@ void TeamManager::readTeamFromConfig(essentials::SystemConfig* sc)
         AlicaEngine::abort("TM: Could not find own agent name in Globals Id = ", localAgentName);
     }
 
-    if ((*sc)["Alica"]->get<bool>("Alica.TeamBlackList.InitiallyFull", NULL)) {
+    if (sc["Alica"]->get<bool>("Alica.TeamBlackList.InitiallyFull", NULL)) {
         for (auto& agentEntry : _agents) {
             agentEntry.second->setIgnored(true);
         }

--- a/alica_tests/include/test_alica.h
+++ b/alica_tests/include/test_alica.h
@@ -24,7 +24,6 @@
 class AlicaTestFixtureBase : public ::testing::Test
 {
 protected:
-    essentials::SystemConfig* sc;
     alica::AlicaEngine* ae;
     alica::BehaviourCreator* bc;
     alica::ConditionCreator* cc;
@@ -46,14 +45,13 @@ protected:
         nh.param<std::string>("/rootPath", path, ".");
 
         // bring up the SystemConfig with the corresponding path
-        sc = essentials::SystemConfig::getInstance();
-        sc->setRootPath(path);
-        sc->setConfigPath(path + "/etc");
-        sc->setHostname("nase");
+        essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+        sc.setRootPath(path);
+        sc.setConfigPath(path + "/etc");
+        sc.setHostname("nase");
 
         // setup the engine
-        ae = new alica::AlicaEngine(
-                new essentials::AgentIDManager(new essentials::AgentIDFactory()), getRoleSetName(), getMasterPlanName(), stepEngine());
+        ae = new alica::AlicaEngine(new essentials::AgentIDManager(new essentials::AgentIDFactory()), getRoleSetName(), getMasterPlanName(), stepEngine());
         bc = new alica::BehaviourCreator();
         cc = new alica::ConditionCreator();
         uc = new alica::UtilityFunctionCreator();
@@ -67,7 +65,7 @@ protected:
     void TearDown() override
     {
         ae->shutdown();
-        sc->shutdown();
+        essentials::SystemConfig::getInstance().shutdown();
         delete ae->getCommunicator();
         delete cc;
         delete bc;

--- a/alica_tests/src/test/test_alica_authority.cpp
+++ b/alica_tests/src/test/test_alica_authority.cpp
@@ -34,10 +34,10 @@ protected:
         std::string path;
         nh.param<std::string>("/rootPath", path, ".");
         // bring up the SystemConfig with the corresponding path
-        sc = essentials::SystemConfig::getInstance();
-        sc->setRootPath(path);
-        sc->setConfigPath(path + "/etc");
-        sc->setHostname("nase");
+        essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+        sc.setRootPath(path);
+        sc.setConfigPath(path + "/etc");
+        sc.setHostname("nase");
 
         // setup the engine parts
         bc = new alica::BehaviourCreator();
@@ -50,7 +50,7 @@ protected:
     {
         ae->shutdown();
         ae2->shutdown();
-        sc->shutdown();
+        essentials::SystemConfig::getInstance().shutdown();
         delete ae->getCommunicator();
         delete ae2->getCommunicator();
         delete cc;
@@ -107,14 +107,14 @@ TEST(AllocationDifference, MessageCancelsUtil)
 TEST_F(AlicaEngineAuthorityManager, authority)
 {
     // ASSERT_NO_SIGNAL
-
-    sc->setHostname("nase");
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    sc.setHostname("nase");
     ae = new alica::AlicaEngine(new essentials::AgentIDManager(new essentials::AgentIDFactory()), "RolesetTA", "AuthorityTestMaster", true);
     ae->setAlicaClock(new alica::AlicaClock());
     ae->setCommunicator(new alicaDummyProxy::AlicaDummyCommunication(ae));
     EXPECT_TRUE(ae->init(bc, cc, uc, crc)) << "Unable to initialise the Alica Engine!";
 
-    sc->setHostname("hairy");
+    sc.setHostname("hairy");
     ae2 = new alica::AlicaEngine(new essentials::AgentIDManager(new essentials::AgentIDFactory()), "RolesetTA", "AuthorityTestMaster", true);
     ae2->setAlicaClock(new alica::AlicaClock());
     ae2->setCommunicator(new alicaDummyProxy::AlicaDummyCommunication(ae2));

--- a/alica_tests/src/test/test_alica_engine_plan_parser.cpp
+++ b/alica_tests/src/test/test_alica_engine_plan_parser.cpp
@@ -585,7 +585,8 @@ TEST_F(AlicaEngineTest, planWriter)
     for (const alica::Plan* plan : plans) {
         cout << "AlicaEngineTest, planWriter: Writing Plan " << plan->getName() << endl;
         pw.saveSinglePlan(plan);
-        string temp = essentials::FileSystem::combinePaths(sc->getConfigPath(), "plans/tmp");
+        essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+        string temp = essentials::FileSystem::combinePaths(sc.getConfigPath(), "plans/tmp");
         temp = essentials::FileSystem::combinePaths(temp, plan->getName() + string(".pml"));
         string test = exec((string("diff ") + plan->getFileName() + string(" ") + temp).c_str());
         EXPECT_EQ(0, test.size()) << "files are different! " << test << endl;

--- a/alica_tests/src/test/test_alica_multi_agent_plan.cpp
+++ b/alica_tests/src/test/test_alica_multi_agent_plan.cpp
@@ -18,8 +18,8 @@
 #include <communication/AlicaDummyCommunication.h>
 #include <engine/AlicaClock.h>
 #include <engine/AlicaEngine.h>
-#include <gtest/gtest.h>
 #include <essentials/AgentIDManager.h>
+#include <gtest/gtest.h>
 #include <test_alica.h>
 
 class AlicaMultiAgent : public AlicaTestFixtureBase
@@ -35,9 +35,9 @@ protected:
         nh.param<std::string>("/rootPath", path, ".");
         std::cout << "rootPath " << path << std::endl;
         // bring up the SystemConfig with the corresponding path
-        sc = essentials::SystemConfig::getInstance();
-        sc->setRootPath(path);
-        sc->setConfigPath(path + "/etc");
+        essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+        sc.setRootPath(path);
+        sc.setConfigPath(path + "/etc");
         // setup the engine
         bc = new alica::BehaviourCreator();
         cc = new alica::ConditionCreator();
@@ -51,7 +51,7 @@ protected:
         ae2->shutdown();
         delete ae->getCommunicator();
         delete ae2->getCommunicator();
-        sc->shutdown();
+        essentials::SystemConfig::getInstance().shutdown();
         delete cc;
         delete bc;
         delete uc;
@@ -65,13 +65,14 @@ TEST_F(AlicaMultiAgent, runMultiAgentPlan)
 {
     ASSERT_NO_SIGNAL
 
-    sc->setHostname("nase");
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    sc.setHostname("nase");
     ae = new alica::AlicaEngine(new essentials::AgentIDManager(new essentials::AgentIDFactory()), "RolesetTA", "MultiAgentTestMaster", true);
     ae->setAlicaClock(new alica::AlicaClock());
     ae->setCommunicator(new alicaDummyProxy::AlicaDummyCommunication(ae));
     ASSERT_TRUE(ae->init(bc, cc, uc, crc)) << "Unable to initialise the Alica Engine!";
 
-    sc->setHostname("hairy");
+    sc.setHostname("hairy");
     ae2 = new alica::AlicaEngine(new essentials::AgentIDManager(new essentials::AgentIDFactory()), "RolesetTA", "MultiAgentTestMaster", true);
     ae2->setAlicaClock(new alica::AlicaClock());
     ae2->setCommunicator(new alicaDummyProxy::AlicaDummyCommunication(ae2));

--- a/alica_tests/src/test/test_alica_sync_transition.cpp
+++ b/alica_tests/src/test/test_alica_sync_transition.cpp
@@ -32,10 +32,10 @@ protected:
         nh.param<std::string>("/rootPath", path, ".");
 
         // bring up the SystemConfig with the corresponding path
-        sc = essentials::SystemConfig::getInstance();
-        sc->setRootPath(path);
-        sc->setConfigPath(path + "/etc");
-        sc->setHostname("nase");
+        essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+        sc.setRootPath(path);
+        sc.setConfigPath(path + "/etc");
+        sc.setHostname("nase");
 
         // setup the engine
         bc = new alica::BehaviourCreator();
@@ -48,7 +48,7 @@ protected:
     {
         ae->shutdown();
         ae2->shutdown();
-        sc->shutdown();
+        essentials::SystemConfig::getInstance().shutdown();
         delete cc;
         delete bc;
         delete uc;
@@ -67,13 +67,14 @@ TEST_F(AlicaSyncTransition, syncTransitionTest)
 {
     ASSERT_NO_SIGNAL
 
-    sc->setHostname("hairy");
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    sc.setHostname("hairy");
     ae = new alica::AlicaEngine(new essentials::AgentIDManager(new essentials::AgentIDFactory()), "RolesetTA", "RealMasterPlanForSyncTest", true);
     ae->setAlicaClock(new alica::AlicaClock());
     ae->setCommunicator(new alicaDummyProxy::AlicaDummyCommunication(ae));
     EXPECT_TRUE(ae->init(bc, cc, uc, crc)) << "Unable to initialise the Alica Engine!";
 
-    sc->setHostname("nase");
+    sc.setHostname("nase");
     ae2 = new alica::AlicaEngine(new essentials::AgentIDManager(new essentials::AgentIDFactory()), "RolesetTA", "RealMasterPlanForSyncTest", true);
     ae2->setAlicaClock(new alica::AlicaClock());
     ae2->setCommunicator(new alicaDummyProxy::AlicaDummyCommunication(ae2));

--- a/alica_tests/src/test/test_assignment.cpp
+++ b/alica_tests/src/test/test_assignment.cpp
@@ -4,9 +4,9 @@
 #include <engine/model/State.h>
 #include <engine/model/Transition.h>
 #include <engine/parser/PlanParser.h>
+#include <essentials/AgentIDFactory.h>
 #include <gtest/gtest.h>
 #include <ros/ros.h>
-#include <essentials/AgentIDFactory.h>
 #include <vector>
 
 using alica::Assignment;
@@ -26,10 +26,10 @@ TEST(Assignment, RobotsInserted)
     nh.param<std::string>("/rootPath", path, ".");
 
     // bring up the SystemConfig with the corresponding path
-    essentials::SystemConfig* sc =essentials::SystemConfig::getInstance();
-    sc->setRootPath(path);
-    sc->setConfigPath(path + "/etc");
-    sc->setHostname("nase");
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    sc.setRootPath(path);
+    sc.setConfigPath(path + "/etc");
+    sc.setHostname("nase");
 
     AgentIDFactory idfac;
     std::vector<uint8_t> b1 = {0x2, 0, 0, 0};

--- a/alica_tests/src/test/test_task_assignment.cpp
+++ b/alica_tests/src/test/test_task_assignment.cpp
@@ -44,12 +44,12 @@ protected:
         nh.param<std::string>("/rootPath", path, ".");
 
         // bring up the SystemConfig with the corresponding path
-        sc = essentials::SystemConfig::getInstance();
-        sc->setRootPath(path);
-        sc->setConfigPath(path + "/etc");
-        cout << sc->getConfigPath() << endl;
+        essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+        sc.setRootPath(path);
+        sc.setConfigPath(path + "/etc");
+        cout << sc.getConfigPath() << endl;
 
-        sc->setHostname("nase");
+        sc.setHostname("nase");
         ae = new alica::AlicaEngine(new essentials::AgentIDManager(new essentials::AgentIDFactory()), "RolesetTA", "MasterPlanTaskAssignment", false);
         bc = new alica::BehaviourCreator();
         cc = new alica::ConditionCreator();
@@ -62,7 +62,7 @@ protected:
     virtual void TearDown()
     {
         ae->shutdown();
-        sc->shutdown();
+        essentials::SystemConfig::getInstance().shutdown();
         delete bc;
         delete cc;
         delete uc;


### PR DESCRIPTION
1) SystemConfig::getInstance() now returns reference.
2) Removed caching singleton SystemConfig instance as private members.