### PR TITLE
Follow naming convention in engine

### DIFF
--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -60,19 +60,19 @@ public:
     std::string getRobotName() const;
 
     // Module Access:
-    AuthorityManager* getAuth() const { return auth; }
-    BehaviourPool* getBehaviourPool() const { return behaviourPool; }
-    const IAlicaCommunication* getCommunicator() const { return communicator; }
-    Logger* getLog() const { return log; }
-    PlanBase* getPlanBase() const { return planBase; }
-    PlanParser* getPlanParser() const { return planParser; }
-    PlanRepository* getPlanRepository() const { return planRepository; }
-    VariableSyncModule* getResultStore() const { return variableSyncModule; }
-    IRoleAssignment* getRoleAssignment() const { return roleAssignment; }
-    SyncModule* getSyncModul() const { return syncModul; }
+    AuthorityManager* getAuth() const { return _auth; }
+    BehaviourPool* getBehaviourPool() const { return _behaviourPool; }
+    const IAlicaCommunication* getCommunicator() const { return _communicator; }
+    Logger* getLog() const { return _log; }
+    PlanBase* getPlanBase() const { return _planBase; }
+    PlanParser* getPlanParser() const { return _planParser; }
+    PlanRepository* getPlanRepository() const { return _planRepository; }
+    VariableSyncModule* getResultStore() const { return _variableSyncModule; }
+    IRoleAssignment* getRoleAssignment() const { return _roleAssignment; }
+    SyncModule* getSyncModul() const { return _syncModul; }
     TeamManager* getTeamManager() const { return _teamManager; }
-    TeamObserver* getTeamObserver() const { return teamObserver; }
-    AlicaClock* getAlicaClock() const { return alicaClock; }
+    TeamObserver* getTeamObserver() const { return _teamObserver; }
+    AlicaClock* getAlicaClock() const { return _alicaClock; }
 
     const BlackBoard& getBlackBoard() const { return _blackboard; }
     BlackBoard& editBlackBoard() { return _blackboard; }
@@ -84,7 +84,7 @@ public:
 
     // Data Access:
 
-    const RoleSet* getRoleSet() const { return roleSet; }
+    const RoleSet* getRoleSet() const { return _roleSet; }
 
     // Setters:
     void setMaySendMessages(bool maySendMessages);
@@ -113,25 +113,25 @@ public:
 private:
     void setStepEngine(bool stepEngine);
 
-    PlanBase* planBase;
-    TeamObserver* teamObserver;
-    ExpressionHandler* expressionHandler;
-    BehaviourPool* behaviourPool;
-    const RoleSet* roleSet;
-    VariableSyncModule* variableSyncModule;
-    AuthorityManager* auth;
+    PlanBase* _planBase;
+    TeamObserver* _teamObserver;
+    ExpressionHandler* _expressionHandler;
+    BehaviourPool* _behaviourPool;
+    const RoleSet* _roleSet;
+    VariableSyncModule* _variableSyncModule;
+    AuthorityManager* _auth;
     TeamManager* _teamManager;
-    SyncModule* syncModul;
-    PlanRepository* planRepository;
+    SyncModule* _syncModul;
+    PlanRepository* _planRepository;
     BlackBoard _blackboard;
 
-    essentials::AgentIDManager* agentIDManager;
-    Logger* log;
-    PlanParser* planParser;
+    essentials::AgentIDManager* _agentIDManager;
+    Logger* _log;
+    PlanParser* _planParser;
 
-    IRoleAssignment* roleAssignment;
-    IAlicaCommunication* communicator;
-    AlicaClock* alicaClock;
+    IRoleAssignment* _roleAssignment;
+    IAlicaCommunication* _communicator;
+    AlicaClock* _alicaClock;
 
     /**
      * Switch the engine between normal operation and silent mode, in which no messages other than debugging information
@@ -142,21 +142,21 @@ private:
     /**
      * Set to have the engine's main loop wait on a signal via MayStep
      */
-    bool stepEngine;
+    bool _stepEngine;
     /**
      * Indicates whether the engine is shutting down.
      */
-    bool terminating;
+    bool _terminating;
 
     /**
      * Indicates whether the engine should run with a static role assignment
      * that is based on default roles, or not.
      */
-    bool useStaticRoles;
+    bool _useStaticRoles;
 
-    bool stepCalled;
+    bool _stepCalled;
 
-    const Plan* masterPlan;
+    const Plan* _masterPlan;
     std::unordered_map<size_t, ISolverBase*> _solvers;
 };
 
@@ -171,7 +171,7 @@ private:
 template <class Prototype>
 AgentIDConstPtr AlicaEngine::getId(Prototype& idPrototype) const
 {
-    return AgentIDConstPtr(this->agentIDManager->getID<Prototype>(idPrototype));
+    return AgentIDConstPtr(_agentIDManager->getID<Prototype>(idPrototype));
 }
 
 template <typename T>

--- a/alica_engine/include/engine/IRoleAssignment.h
+++ b/alica_engine/include/engine/IRoleAssignment.h
@@ -23,7 +23,7 @@ public:
     virtual void tick() = 0;
     virtual void update() = 0;
 
-    const Role* getOwnRole() const { return ownRole; }
+    const Role* getOwnRole() const { return _ownRole; }
     const Role* getRole(AgentIDConstPtr robotId);
     void setCommunication(const IAlicaCommunication* communication);
 
@@ -31,8 +31,8 @@ protected:
     /**
      * Current Robot's role.
      */
-    const Role* ownRole;
-    std::map<AgentIDConstPtr, const Role*> robotRoleMapping;
-    const IAlicaCommunication* communication;
+    const Role* _ownRole;
+    std::map<AgentIDConstPtr, const Role*> _robotRoleMapping;
+    const IAlicaCommunication* _communication;
 };
 } // namespace alica

--- a/alica_engine/include/engine/Logger.h
+++ b/alica_engine/include/engine/Logger.h
@@ -80,20 +80,20 @@ private:
     void evaluationAssignmentsToString(std::stringstream& ss, const RunningPlan& rp);
     std::stringstream& createTreeLog(std::stringstream& ss, const RunningPlan& r);
 
-    AlicaEngine* ae;
-    TeamObserver* to;
-    TeamManager* tm;
-    AlicaTime startTime;
-    AlicaTime endTime;
-    AlicaTime time;
+    AlicaEngine* _ae;
+    TeamObserver* _to;
+    TeamManager* _tm;
+    AlicaTime _startTime;
+    AlicaTime _endTime;
+    AlicaTime _time;
     std::ofstream _fileWriter;
     std::stringstream _sBuild;
-    std::list<std::string> eventStrings;
-    int itCount;
+    std::list<std::string> _eventStrings;
+    int _itCount;
 
     bool _active;
-    bool receivedEvent;
-    bool inIteration;
+    bool _receivedEvent;
+    bool _inIteration;
 };
 
 } /* namespace alica */

--- a/alica_engine/include/engine/RunningPlan.h
+++ b/alica_engine/include/engine/RunningPlan.h
@@ -233,7 +233,7 @@ private:
 
     mutable std::mutex _accessMutex;
 
-    static AlicaTime assignmentProtectionTime;
+    static AlicaTime s_assignmentProtectionTime;
 };
 
 std::ostream& operator<<(std::ostream& out, const RunningPlan& r);

--- a/alica_engine/include/engine/StaticRoleAssignment.h
+++ b/alica_engine/include/engine/StaticRoleAssignment.h
@@ -23,9 +23,8 @@ public:
     void calculateRoles();
 
 private:
-    bool updateRoles;
-
-    AlicaEngine* ae;
+    bool _updateRoles;
+    AlicaEngine* _ae;
 };
 
 } /* namespace alica */

--- a/alica_engine/include/engine/TeamObserver.h
+++ b/alica_engine/include/engine/TeamObserver.h
@@ -54,7 +54,7 @@ private:
     TeamManager* _tm;
 
     std::mutex _msgQueueMutex;
-    mutable std::mutex successMarkMutex;
+    mutable std::mutex _successMarkMutex;
 
     std::map<AgentIDConstPtr, std::unique_ptr<SimplePlanTree>> _simplePlanTrees;
     std::vector<std::pair<std::shared_ptr<PlanTreeInfo>, AlicaTime>> _msgQueue;

--- a/alica_engine/include/engine/allocationauthority/CycleManager.h
+++ b/alica_engine/include/engine/allocationauthority/CycleManager.h
@@ -49,21 +49,19 @@ private:
     AlicaEngine* _ae;
     std::vector<AllocationDifference> _allocationHistory;
     int _newestAllocationDifference;
-    int maxAllocationCycles;
-    bool enabled;
-
-    AgentIDConstPtr myID;
-
-    AlicaTime overrideTimestamp;
-    double intervalIncFactor;
-    double intervalDecFactor;
-    AlicaTime minimalOverrideTimeInterval;
-    AlicaTime maximalOverrideTimeInterval;
-    AlicaTime overrideShoutInterval;
-    AlicaTime overrideWaitInterval;
-    AlicaTime overrideShoutTime;
+    int _maxAllocationCycles;
+    bool _enabled;
+    AgentIDConstPtr _myID;
+    AlicaTime _overrideTimestamp;
+    double _intervalIncFactor;
+    double _intervalDecFactor;
+    AlicaTime _minimalOverrideTimeInterval;
+    AlicaTime _maximalOverrideTimeInterval;
+    AlicaTime _overrideShoutInterval;
+    AlicaTime _overrideWaitInterval;
+    AlicaTime _overrideShoutTime;
     CycleState _state;
-    RunningPlan* rp;
+    RunningPlan* _rp;
     AllocationAuthorityInfo _fixedAllocation;
 };
 

--- a/alica_engine/include/engine/allocationauthority/EntryPointRobotPair.h
+++ b/alica_engine/include/engine/allocationauthority/EntryPointRobotPair.h
@@ -22,7 +22,7 @@ public:
     bool operator==(const EntryPointRobotPair& o) const;
     bool operator!=(const EntryPointRobotPair& o) const { return !(*this == o); }
 
-protected:
+private:
     const EntryPoint* _entryPoint;
     AgentIDConstPtr _robot;
 };

--- a/alica_engine/include/engine/constraintmodul/ConditionStore.h
+++ b/alica_engine/include/engine/constraintmodul/ConditionStore.h
@@ -35,7 +35,6 @@ public:
 private:
     ConditionGrp _activeConditions;
     std::map<const Variable*, ConditionGrp> _activeVar2CondMap;
-
     mutable std::mutex _mtx;
 };
 

--- a/alica_engine/include/engine/containers/AllocationAuthorityInfo.h
+++ b/alica_engine/include/engine/containers/AllocationAuthorityInfo.h
@@ -32,14 +32,14 @@ struct AllocationAuthorityInfo
 
     AllocationAuthorityInfo(const stdAllocationAuthorityInfo& s)
     {
-        this->senderID = std::get<0>(s);
-        this->planId = std::get<1>(s);
-        this->parentState = std::get<2>(s);
-        this->planType = std::get<3>(s);
-        this->authority = std::get<4>(s);
+        senderID = std::get<0>(s);
+        planId = std::get<1>(s);
+        parentState = std::get<2>(s);
+        planType = std::get<3>(s);
+        authority = std::get<4>(s);
         const std::vector<stdEntryPointRobot>& tmp = std::get<5>(s);
         for (const stdEntryPointRobot& e : tmp) {
-            this->entryPointRobots.push_back(EntryPointRobots(e));
+            entryPointRobots.push_back(EntryPointRobots(e));
         }
     }
 

--- a/alica_engine/include/engine/containers/SyncData.h
+++ b/alica_engine/include/engine/containers/SyncData.h
@@ -32,10 +32,10 @@ struct SyncData
     void toString() const
     {
         std::cout << "SyncData--> ";
-        std::cout << " RobotId: " << this->robotID;
-        std::cout << " TransitionID: " << this->transitionID;
-        std::cout << " ConditionHolds: " << this->conditionHolds;
-        std::cout << " Acknowledge: " << this->ack << std::endl;
+        std::cout << " RobotId: " << robotID;
+        std::cout << " TransitionID: " << transitionID;
+        std::cout << " ConditionHolds: " << conditionHolds;
+        std::cout << " Acknowledge: " << ack << std::endl;
     }
 
     AgentIDConstPtr robotID;

--- a/alica_engine/include/engine/expressionhandler/ExpressionHandler.h
+++ b/alica_engine/include/engine/expressionhandler/ExpressionHandler.h
@@ -8,7 +8,8 @@
 #ifndef EXPRESSIONHANDLER_H_
 #define EXPRESSIONHANDLER_H_
 
-namespace alica {
+namespace alica
+{
 class RunningPlan;
 class Plan;
 class Condition;
@@ -21,7 +22,8 @@ class AlicaEngine;
 /**
  * The ExpressionHandler attaches expressions and constraints to plans during start-up of the engine.
  */
-class ExpressionHandler {
+class ExpressionHandler
+{
 public:
     ExpressionHandler(AlicaEngine* ae, IConditionCreator* cc, IUtilityCreator* uc, IConstraintCreator* crc);
     virtual ~ExpressionHandler();
@@ -31,10 +33,10 @@ public:
     bool dummyFalse(RunningPlan* rp);
 
 private:
-    IConditionCreator* conditionCreator;
-    IUtilityCreator* utilityCreator;
-    IConstraintCreator* constraintCreator;
-    AlicaEngine* ae;
+    IConditionCreator* _conditionCreator;
+    IUtilityCreator* _utilityCreator;
+    IConstraintCreator* _constraintCreator;
+    AlicaEngine* _ae;
     //		void attachPlanConditions(Plan* p, T exprType, T consType);
     //		void attachTransConditions(Transition* t, T exprType, T consType);
     void attachConstraint(Condition* c);

--- a/alica_engine/include/engine/model/Parameter.h
+++ b/alica_engine/include/engine/model/Parameter.h
@@ -4,9 +4,11 @@
 
 #include <engine/model/AlicaElement.h>
 
-namespace alica {
+namespace alica
+{
 
-class Parameter : public AlicaElement {
+class Parameter : public AlicaElement
+{
 public:
     Parameter();
     virtual ~Parameter();
@@ -15,7 +17,7 @@ public:
     const std::string& getValue() const { return _value; }
     void setValue(const std::string& value) { _value = value; }
 
-protected:
+private:
     std::string _key;
     std::string _value;
 };

--- a/alica_engine/include/engine/parser/ModelFactory.h
+++ b/alica_engine/include/engine/parser/ModelFactory.h
@@ -8,9 +8,9 @@
 #ifndef MODELFACTORY_H_
 #define MODELFACTORY_H_
 
-#include <list>
 #include <map>
 #include <memory>
+#include <vector>
 
 #include "tinyxml2.h"
 
@@ -57,7 +57,7 @@ public:
     bool getIgnoreMasterPlanId();
     void setIgnoreMasterPlanId(bool value);
     Plan* createPlan(tinyxml2::XMLDocument* node);
-    std::map<int64_t, AlicaElement*>* getElements();
+    bool isUniqueElement(int64_t elementId);
     void setElements(const std::map<int64_t, AlicaElement*>& elements);
     std::string getNameOfNode(tinyxml2::XMLElement* node);
     void createTasks(tinyxml2::XMLDocument* node);
@@ -115,7 +115,7 @@ private:
     PlanRepository* _rep;
     std::map<int64_t, AlicaElement*> _elements;
 
-    using ReferenceList = std::list<std::pair<int64_t, int64_t>>;
+    using ReferenceList = std::vector<std::pair<int64_t, int64_t>>;
 
     ReferenceList _stateInTransitionReferences;
     ReferenceList _stateOutTransitionReferences;
@@ -161,6 +161,8 @@ private:
 
     void createVariableTemplates();
     void removeRedundancy();
+    template <class ff, class ss>
+    void iterateAndClear(ReferenceList& l, std::function<void(ff*, ss*)> func);
 };
 } // namespace alica
 

--- a/alica_engine/include/engine/parser/ModelFactory.h
+++ b/alica_engine/include/engine/parser/ModelFactory.h
@@ -8,13 +8,14 @@
 #ifndef MODELFACTORY_H_
 #define MODELFACTORY_H_
 
-#include <memory>
 #include <list>
 #include <map>
+#include <memory>
 
 #include "tinyxml2.h"
 
-namespace alica {
+namespace alica
+{
 class PlanParser;
 class PlanRepository;
 class Plan;
@@ -46,7 +47,8 @@ class Parameter;
 /**
  * Constructs Model elements, i.e., objects inheriting from <see cref="PlanElement"/> given their XML representation.
  */
-class ModelFactory {
+class ModelFactory
+{
 public:
     ModelFactory(PlanParser* p, PlanRepository* rep);
     virtual ~ModelFactory();
@@ -109,31 +111,31 @@ private:
     static const std::string waitPlan;
     static const std::string alternativePlan;
 
-    PlanParser* parser;
-    PlanRepository* rep;
-    std::map<int64_t, AlicaElement*> elements;
+    PlanParser* _parser;
+    PlanRepository* _rep;
+    std::map<int64_t, AlicaElement*> _elements;
 
     using ReferenceList = std::list<std::pair<int64_t, int64_t>>;
 
-    ReferenceList stateInTransitionReferences;
-    ReferenceList stateOutTransitionReferences;
-    ReferenceList statePlanReferences;
-    ReferenceList transitionSynchReferences;
-    ReferenceList transitionAimReferences;
-    ReferenceList paramSubPlanReferences;
-    ReferenceList paramSubVarReferences;
-    ReferenceList paramVarReferences;
-    ReferenceList conditionVarReferences;
-    ReferenceList quantifierScopeReferences;
-    ReferenceList epStateReferences;
-    ReferenceList epTaskReferences;
-    ReferenceList planTypePlanReferences;
-    ReferenceList rtmRoleReferences;
-    ReferenceList charCapReferences;
-    ReferenceList charCapValReferences;
-    ReferenceList planningProblemPlanReferences;
-    ReferenceList planningProblemPlanWaitReferences;
-    ReferenceList planningProblemPlanAlternativeReferences;
+    ReferenceList _stateInTransitionReferences;
+    ReferenceList _stateOutTransitionReferences;
+    ReferenceList _statePlanReferences;
+    ReferenceList _transitionSynchReferences;
+    ReferenceList _paramSubPlanReferences;
+    ReferenceList _transitionAimReferences;
+    ReferenceList _paramSubVarReferences;
+    ReferenceList _paramVarReferences;
+    ReferenceList _conditionVarReferences;
+    ReferenceList _quantifierScopeReferences;
+    ReferenceList _epStateReferences;
+    ReferenceList _epTaskReferences;
+    ReferenceList _planTypePlanReferences;
+    ReferenceList _rtmRoleReferences;
+    ReferenceList _charCapReferences;
+    ReferenceList _charCapValReferences;
+    ReferenceList _planningProblemPlanReferences;
+    ReferenceList _planningProblemPlanWaitReferences;
+    ReferenceList _planningProblemPlanAlternativeReferences;
 
     void setAlicaElementAttributes(AlicaElement* ae, tinyxml2::XMLElement* ele);
     EntryPoint* createEntryPoint(tinyxml2::XMLElement* element);
@@ -160,6 +162,6 @@ private:
     void createVariableTemplates();
     void removeRedundancy();
 };
-}  // namespace alica
+} // namespace alica
 
 #endif /* MODELFACTORY_H_ */

--- a/alica_engine/include/engine/parser/PlanParser.h
+++ b/alica_engine/include/engine/parser/PlanParser.h
@@ -37,22 +37,25 @@ public:
     void ignoreMasterPlanId(bool val);
     std::map<int64_t, AlicaElement*>* getParsedElements();
 
-    const std::string& getCurrentFile() const { return currentFile; }
+    const std::string& getCurrentFile() const { return _currentFile; }
     void setCurrentFile(const std::string& currentFile);
     void parseFileLoop();
     const RoleSet* parseRoleSet(std::string roleSetName);
     int64_t parserId(tinyxml2::XMLElement* node);
 
 private:
-    std::shared_ptr<ModelFactory> mf;
-    PlanRepository* rep;
-    Plan* masterPlan;
-    std::string planDir;
-    std::string roleDir;
-    std::string basePlanPath;
-    std::string baseRolePath;
-    std::string currentDirectory;
-    std::string currentFile;
+    std::shared_ptr<ModelFactory> _mf;
+    PlanRepository* _rep;
+    Plan* _masterPlan;
+    std::string _planDir;
+    std::string _roleDir;
+    std::string _basePlanPath;
+    std::string _baseRolePath;
+    std::string _currentDirectory;
+    std::string _currentFile;
+    std::list<std::string> _filesToParse;
+    std::list<std::string> _filesParsed;
+
     void parseTaskFile(const std::string& currentFile);
     void parseRoleDefFile(const std::string& currentFile);
     void parseCapabilityDefFile(const std::string& currentFile);
@@ -62,8 +65,5 @@ private:
     Plan* parsePlanFile(const std::string& planFile);
     int64_t fetchId(const std::string& idString, int64_t id);
     std::string findDefaultRoleSet(std::string dir);
-
-    std::list<std::string> filesToParse;
-    std::list<std::string> filesParsed;
 };
 } // namespace alica

--- a/alica_engine/include/engine/parser/PlanParser.h
+++ b/alica_engine/include/engine/parser/PlanParser.h
@@ -49,7 +49,7 @@ private:
     std::string _baseRolePath;
     std::string _currentDirectory;
     std::string _currentFile;
-    std::list<std::string> _filesToParse;
+    std::vector<std::string> _filesToParse;
     std::vector<std::string> _filesParsed;
 
     void parseFile(const std::string& currentFile, tinyxml2::XMLDocument& doc);

--- a/alica_engine/include/engine/parser/PlanParser.h
+++ b/alica_engine/include/engine/parser/PlanParser.h
@@ -6,19 +6,15 @@
 #include <list>
 #include <stdio.h>
 #include <string>
+#include <vector>
 
+#include "engine/parser/ModelFactory.h"
 #include <FileSystem.h>
 #include <SystemConfig.h>
-
-namespace tinyxml2
-{
-class XMLElement;
-}
 
 namespace alica
 {
 
-class ModelFactory;
 class PlanRepository;
 class Plan;
 class RoleSet;
@@ -35,7 +31,7 @@ public:
 
     const Plan* parsePlanTree(const std::string& masterplan);
     void ignoreMasterPlanId(bool val);
-    std::map<int64_t, AlicaElement*>* getParsedElements();
+    bool isUniqueElement(int64_t elementId);
 
     const std::string& getCurrentFile() const { return _currentFile; }
     void setCurrentFile(const std::string& currentFile);
@@ -44,7 +40,7 @@ public:
     int64_t parserId(tinyxml2::XMLElement* node);
 
 private:
-    std::shared_ptr<ModelFactory> _mf;
+    ModelFactory _mf;
     PlanRepository* _rep;
     Plan* _masterPlan;
     std::string _planDir;
@@ -54,8 +50,9 @@ private:
     std::string _currentDirectory;
     std::string _currentFile;
     std::list<std::string> _filesToParse;
-    std::list<std::string> _filesParsed;
+    std::vector<std::string> _filesParsed;
 
+    void parseFile(const std::string& currentFile, tinyxml2::XMLDocument& doc);
     void parseTaskFile(const std::string& currentFile);
     void parseRoleDefFile(const std::string& currentFile);
     void parseCapabilityDefFile(const std::string& currentFile);

--- a/alica_engine/include/engine/parser/PlanWriter.h
+++ b/alica_engine/include/engine/parser/PlanWriter.h
@@ -61,9 +61,9 @@ public:
     tinyxml2::XMLDocument* createTaskRepositoryXMLDocument(const TaskRepository* tr);
 
 private:
-    PlanRepository* rep;
-    std::string currentFile;
-    static int objectCounter;
+    PlanRepository* _rep;
+    std::string _currentFile;
+    static int s_objectCounter;
 
     std::string getRelativeFileName(const std::string& file);
     std::string getRelativeFileName(const AbstractPlan* p);

--- a/alica_engine/include/engine/parser/PlanWriter.h
+++ b/alica_engine/include/engine/parser/PlanWriter.h
@@ -63,7 +63,7 @@ public:
 private:
     PlanRepository* _rep;
     std::string _currentFile;
-    static int s_objectCounter;
+    int _objectCounter;
 
     std::string getRelativeFileName(const std::string& file);
     std::string getRelativeFileName(const AbstractPlan* p);
@@ -84,10 +84,10 @@ private:
     tinyxml2::XMLElement* createEntryPointXMLNode(const EntryPoint* e, tinyxml2::XMLDocument* doc);
 
 protected:
-    AlicaEngine* ae;
-    std::string tempPlanDir;
-    AlicaElementGrp plansToSave;
-    AlicaElementGrp plansSaved;
+    AlicaEngine* _ae;
+    std::string _tempPlanDir;
+    AlicaElementGrp _plansToSave;
+    AlicaElementGrp _plansSaved;
 };
 
 } /* namespace alica */

--- a/alica_engine/include/engine/syncmodule/SyncModule.h
+++ b/alica_engine/include/engine/syncmodule/SyncModule.h
@@ -41,15 +41,15 @@ public:
     void synchronisationDone(const SyncTransition* st);
 
 protected:
-    bool running;
-    AlicaEngine* ae;
-    AgentIDConstPtr myId;
-    unsigned long ticks;
-    PlanRepository* pr;
-    std::map<const SyncTransition*, Synchronisation*> synchSet;
-    std::list<const SyncTransition*> synchedTransitions;
-    std::mutex lomutex;
-    const IAlicaCommunication* communicator;
+    bool _running;
+    AlicaEngine* _ae;
+    AgentIDConstPtr _myId;
+    unsigned long _ticks;
+    PlanRepository* _pr;
+    std::map<const SyncTransition*, Synchronisation*> _synchSet;
+    std::list<const SyncTransition*> _synchedTransitions;
+    std::mutex _lomutex;
+    const IAlicaCommunication* _communicator;
 };
 
 } // namespace alica

--- a/alica_engine/include/engine/syncmodule/SyncModule.h
+++ b/alica_engine/include/engine/syncmodule/SyncModule.h
@@ -26,21 +26,21 @@ class SyncModule
 {
 public:
     SyncModule(AlicaEngine* ae);
-    virtual ~SyncModule();
-    virtual void init();
-    virtual void close();
-    virtual void tick();
-    virtual void setSynchronisation(const Transition* trans, bool holds);
-    virtual bool followSyncTransition(const Transition* trans);
-    virtual void onSyncTalk(std::shared_ptr<SyncTalk> st);
-    virtual void onSyncReady(std::shared_ptr<SyncReady> sr);
+    ~SyncModule();
+    void init();
+    void close();
+    void tick();
+    void setSynchronisation(const Transition* trans, bool holds);
+    bool followSyncTransition(const Transition* trans);
+    void onSyncTalk(std::shared_ptr<SyncTalk> st);
+    void onSyncReady(std::shared_ptr<SyncReady> sr);
 
     void sendSyncTalk(SyncTalk& st);
     void sendSyncReady(SyncReady& sr);
     void sendAcks(const std::vector<SyncData>& syncDataList) const;
     void synchronisationDone(const SyncTransition* st);
 
-protected:
+private:
     bool _running;
     AlicaEngine* _ae;
     AgentIDConstPtr _myId;

--- a/alica_engine/include/engine/syncmodule/Synchronisation.h
+++ b/alica_engine/include/engine/syncmodule/Synchronisation.h
@@ -42,7 +42,6 @@ private:
     bool allSyncReady() const;
     friend std::ostream& operator<<(std::ostream& s, const Synchronisation& sync);
 
-protected:
     AlicaEngine* _ae;
     std::mutex _syncMutex;
     std::mutex _rowOkMutex;

--- a/alica_engine/include/engine/syncmodule/Synchronisation.h
+++ b/alica_engine/include/engine/syncmodule/Synchronisation.h
@@ -43,23 +43,23 @@ private:
     friend std::ostream& operator<<(std::ostream& s, const Synchronisation& sync);
 
 protected:
-    AlicaEngine* ae;
-    std::mutex syncMutex;
-    std::mutex rowOkMutex;
-    SyncModule* syncModul;
-    const SyncTransition* syncTransition;
-    AgentIDConstPtr myID;
-    SyncData* lastTalkData;
-    AlicaTime lastTalkTime;
-    AlicaTime syncStartTime;
-    bool readyForSync;
-    uint64_t lastTick;
-    std::vector<std::shared_ptr<SyncReady>> receivedSyncReadys;
-    std::vector<int64_t> connectedTransitions;
-    RunningPlan* runningPlan;
-    std::vector<SyncRow*> rowsOK;
-    std::vector<SyncRow*> syncMatrix;
-    SyncRow* myRow;
+    AlicaEngine* _ae;
+    std::mutex _syncMutex;
+    std::mutex _rowOkMutex;
+    SyncModule* _syncModul;
+    const SyncTransition* _syncTransition;
+    AgentIDConstPtr _myID;
+    SyncData* _lastTalkData;
+    AlicaTime _lastTalkTime;
+    AlicaTime _syncStartTime;
+    bool _readyForSync;
+    uint64_t _lastTick;
+    std::vector<std::shared_ptr<SyncReady>> _receivedSyncReadys;
+    std::vector<int64_t> _connectedTransitions;
+    RunningPlan* _runningPlan;
+    std::vector<SyncRow*> _rowsOK;
+    std::vector<SyncRow*> _syncMatrix;
+    SyncRow* _myRow;
 
     void sendTalk(const SyncData& sd);
     void sendSyncReady();

--- a/alica_engine/include/engine/teammanager/TeamManager.h
+++ b/alica_engine/include/engine/teammanager/TeamManager.h
@@ -36,8 +36,8 @@ public:
     const AgentMap& getAllAgents() const { return _agents; }
 
     AgentIDConstPtr getLocalAgentID() const;
-    const Agent* getLocalAgent() const { return localAgent; }
-    Agent* editLocalAgent() { return localAgent; }
+    const Agent* getLocalAgent() const { return _localAgent; }
+    Agent* editLocalAgent() { return _localAgent; }
 
     ActiveAgentIdView getActiveAgentIds() const;
     ActiveAgentView getActiveAgents() const;
@@ -54,11 +54,11 @@ public:
     const DomainVariable* getDomainVariable(AgentIDConstPtr agentId, const std::string& sort) const;
 
 private:
-    AlicaTime teamTimeOut;
-    Agent* localAgent;
-    AlicaEngine* engine;
+    AlicaTime _teamTimeOut;
+    Agent* _localAgent;
+    AlicaEngine* _engine;
     AgentMap _agents;
-    bool useConfigForTeam;
+    bool _useConfigForTeam;
 
     void readTeamFromConfig();
 };

--- a/alica_engine/src/engine/IRoleAssignment.cpp
+++ b/alica_engine/src/engine/IRoleAssignment.cpp
@@ -5,15 +5,15 @@
 namespace alica
 {
 IRoleAssignment::IRoleAssignment()
-        : ownRole(nullptr)
-        , communication(nullptr)
+        : _ownRole(nullptr)
+        , _communication(nullptr)
 {
 }
 
 const Role* IRoleAssignment::getRole(AgentIDConstPtr robotId)
 {
-    auto iter = this->robotRoleMapping.find(robotId);
-    if (iter != this->robotRoleMapping.end()) {
+    auto iter = _robotRoleMapping.find(robotId);
+    if (iter != _robotRoleMapping.end()) {
         return iter->second;
     } else {
         std::stringstream ss;
@@ -25,7 +25,7 @@ const Role* IRoleAssignment::getRole(AgentIDConstPtr robotId)
 
 void IRoleAssignment::setCommunication(const IAlicaCommunication* communication)
 {
-    this->communication = communication;
+    _communication = communication;
 }
 
 } /* namespace alica */

--- a/alica_engine/src/engine/RunningPlan.cpp
+++ b/alica_engine/src/engine/RunningPlan.cpp
@@ -36,11 +36,11 @@
 namespace alica
 {
 
-AlicaTime RunningPlan::assignmentProtectionTime = AlicaTime::zero();
+AlicaTime RunningPlan::s_assignmentProtectionTime = AlicaTime::zero();
 
 void RunningPlan::init()
 {
-    assignmentProtectionTime =
+    s_assignmentProtectionTime =
             AlicaTime::milliseconds((essentials::SystemConfig::getInstance())["Alica"]->get<unsigned long>("Alica.AssignmentProtectionTime", NULL));
 }
 
@@ -560,8 +560,8 @@ bool RunningPlan::recursiveUpdateAssignment(const std::vector<const SimplePlanTr
     if (isBehaviour()) {
         return false;
     }
-    const bool keepTask = _status.planStartTime + assignmentProtectionTime > now;
-    const bool keepState = _status.stateStartTime + assignmentProtectionTime > now;
+    const bool keepTask = _status.planStartTime + s_assignmentProtectionTime > now;
+    const bool keepState = _status.stateStartTime + s_assignmentProtectionTime > now;
     const bool auth = _cycleManagement.haveAuthority();
 
     // if keepTask, the task Assignment should not be changed!

--- a/alica_engine/src/engine/StaticRoleAssignment.cpp
+++ b/alica_engine/src/engine/StaticRoleAssignment.cpp
@@ -17,8 +17,8 @@ namespace alica
 
 StaticRoleAssignment::StaticRoleAssignment(AlicaEngine* ae)
         : IRoleAssignment()
-        , ae(ae)
-        , updateRoles(false)
+        , _ae(ae)
+        , _updateRoles(false)
 {
 }
 
@@ -35,8 +35,8 @@ void StaticRoleAssignment::init()
  */
 void StaticRoleAssignment::tick()
 {
-    if (this->updateRoles) {
-        this->updateRoles = false;
+    if (this->_updateRoles) {
+        this->_updateRoles = false;
         this->calculateRoles();
     }
 }
@@ -46,7 +46,7 @@ void StaticRoleAssignment::tick()
  */
 void StaticRoleAssignment::update()
 {
-    this->updateRoles = true;
+    this->_updateRoles = true;
 }
 
 /**
@@ -58,10 +58,10 @@ void StaticRoleAssignment::calculateRoles()
     this->robotRoleMapping.clear();
 
     // get data for "calculations"
-    const PlanRepository::Accessor<Role>& roles = ae->getPlanRepository()->getRoles();
+    const PlanRepository::Accessor<Role>& roles = _ae->getPlanRepository()->getRoles();
 
     // assign a role for each robot if you have match
-    for (const Agent* agent : ae->getTeamManager()->getActiveAgents()) {
+    for (const Agent* agent : _ae->getTeamManager()->getActiveAgents()) {
         const RobotProperties& prop = agent->getProperties();
         bool roleIsAssigned = false;
 
@@ -72,7 +72,7 @@ void StaticRoleAssignment::calculateRoles()
                 this->robotRoleMapping.emplace(agent->getId(), role);
 
                 // set own role, if its me
-                if (agent->getId() == this->ae->getTeamManager()->getLocalAgentID() && this->ownRole != role) {
+                if (agent->getId() == this->_ae->getTeamManager()->getLocalAgentID() && this->ownRole != role) {
                     this->ownRole = role;
                     // probably nothing is reacting on this message, but anyway we send it
                     if (this->communication != nullptr) {

--- a/alica_engine/src/engine/StaticRoleAssignment.cpp
+++ b/alica_engine/src/engine/StaticRoleAssignment.cpp
@@ -27,7 +27,7 @@ StaticRoleAssignment::StaticRoleAssignment(AlicaEngine* ae)
  */
 void StaticRoleAssignment::init()
 {
-    this->calculateRoles();
+    calculateRoles();
 }
 
 /**
@@ -35,9 +35,9 @@ void StaticRoleAssignment::init()
  */
 void StaticRoleAssignment::tick()
 {
-    if (this->_updateRoles) {
-        this->_updateRoles = false;
-        this->calculateRoles();
+    if (_updateRoles) {
+        _updateRoles = false;
+        calculateRoles();
     }
 }
 
@@ -46,7 +46,7 @@ void StaticRoleAssignment::tick()
  */
 void StaticRoleAssignment::update()
 {
-    this->_updateRoles = true;
+    _updateRoles = true;
 }
 
 /**
@@ -55,7 +55,7 @@ void StaticRoleAssignment::update()
 void StaticRoleAssignment::calculateRoles()
 {
     // clear current map
-    this->robotRoleMapping.clear();
+    _robotRoleMapping.clear();
 
     // get data for "calculations"
     const PlanRepository::Accessor<Role>& roles = _ae->getPlanRepository()->getRoles();
@@ -69,16 +69,16 @@ void StaticRoleAssignment::calculateRoles()
             // make entry in the map if the roles match
             if (role->getName() == prop.getDefaultRole()) {
                 ALICA_DEBUG_MSG("Static RA: Setting Role " << role->getName() << " for robot ID " << agent->getId());
-                this->robotRoleMapping.emplace(agent->getId(), role);
+                _robotRoleMapping.emplace(agent->getId(), role);
 
                 // set own role, if its me
-                if (agent->getId() == this->_ae->getTeamManager()->getLocalAgentID() && this->ownRole != role) {
-                    this->ownRole = role;
+                if (agent->getId() == _ae->getTeamManager()->getLocalAgentID() && _ownRole != role) {
+                    _ownRole = role;
                     // probably nothing is reacting on this message, but anyway we send it
-                    if (this->communication != nullptr) {
+                    if (_communication != nullptr) {
                         RoleSwitch rs;
                         rs.roleID = role->getId();
-                        this->communication->sendRoleSwitch(rs);
+                        _communication->sendRoleSwitch(rs);
                     }
                 }
                 roleIsAssigned = true;

--- a/alica_engine/src/engine/TeamObserver.cpp
+++ b/alica_engine/src/engine/TeamObserver.cpp
@@ -184,7 +184,7 @@ int TeamObserver::successesInPlan(const Plan* plan)
     const EntryPointGrp* suc = nullptr;
     for (const Agent* agent : _tm->getActiveAgents()) {
         {
-            lock_guard<mutex> lock(this->_successMarkMutex);
+            lock_guard<mutex> lock(_successMarkMutex);
             suc = agent->getSucceededEntryPoints(plan);
         }
         if (suc != nullptr) {
@@ -208,7 +208,7 @@ SuccessCollection TeamObserver::createSuccessCollection(const Plan* plan) const
             continue;
         }
         {
-            lock_guard<mutex> lock(this->_successMarkMutex);
+            lock_guard<mutex> lock(_successMarkMutex);
             suc = agent->getSucceededEntryPoints(plan);
         }
         if (suc != nullptr) {
@@ -236,7 +236,7 @@ void TeamObserver::updateSuccessCollection(const Plan* p, SuccessCollection& sc)
             continue;
         }
         {
-            lock_guard<mutex> lock(this->_successMarkMutex);
+            lock_guard<mutex> lock(_successMarkMutex);
             suc = agent->getSucceededEntryPoints(p);
         }
         if (suc != nullptr) {

--- a/alica_engine/src/engine/TeamObserver.cpp
+++ b/alica_engine/src/engine/TeamObserver.cpp
@@ -184,7 +184,7 @@ int TeamObserver::successesInPlan(const Plan* plan)
     const EntryPointGrp* suc = nullptr;
     for (const Agent* agent : _tm->getActiveAgents()) {
         {
-            lock_guard<mutex> lock(this->successMarkMutex);
+            lock_guard<mutex> lock(this->_successMarkMutex);
             suc = agent->getSucceededEntryPoints(plan);
         }
         if (suc != nullptr) {
@@ -208,7 +208,7 @@ SuccessCollection TeamObserver::createSuccessCollection(const Plan* plan) const
             continue;
         }
         {
-            lock_guard<mutex> lock(this->successMarkMutex);
+            lock_guard<mutex> lock(this->_successMarkMutex);
             suc = agent->getSucceededEntryPoints(plan);
         }
         if (suc != nullptr) {
@@ -236,7 +236,7 @@ void TeamObserver::updateSuccessCollection(const Plan* p, SuccessCollection& sc)
             continue;
         }
         {
-            lock_guard<mutex> lock(this->successMarkMutex);
+            lock_guard<mutex> lock(this->_successMarkMutex);
             suc = agent->getSucceededEntryPoints(p);
         }
         if (suc != nullptr) {

--- a/alica_engine/src/engine/collections/RobotEngineData.cpp
+++ b/alica_engine/src/engine/collections/RobotEngineData.cpp
@@ -65,7 +65,7 @@ const DomainVariable* RobotEngineData::getDomainVariable(const std::string& name
 int64_t RobotEngineData::makeUniqueId(const std::string& s) const
 {
     int64_t ret = static_cast<int64_t>(essentials::AgentIDHash{}(_agentId.get()) + std::hash<std::string>()(s));
-    assert(_engine->getPlanParser()->getParsedElements()->find(ret) == _engine->getPlanParser()->getParsedElements()->end());
+    assert(_engine->getPlanParser()->isUniqueElement(ret));
     return ret;
 }
 

--- a/alica_engine/src/engine/expressionhandler/ExpressionHandler.cpp
+++ b/alica_engine/src/engine/expressionhandler/ExpressionHandler.cpp
@@ -31,10 +31,10 @@ namespace alica
  */
 ExpressionHandler::ExpressionHandler(AlicaEngine* ae, IConditionCreator* cc, IUtilityCreator* uc, IConstraintCreator* crc)
 {
-    this->ae = ae;
-    this->conditionCreator = cc;
-    this->utilityCreator = uc;
-    this->constraintCreator = crc;
+    this->_ae = ae;
+    this->_conditionCreator = cc;
+    this->_utilityCreator = uc;
+    this->_constraintCreator = crc;
 }
 
 ExpressionHandler::~ExpressionHandler()
@@ -47,16 +47,16 @@ ExpressionHandler::~ExpressionHandler()
  */
 void ExpressionHandler::attachAll()
 {
-    PlanRepository* pr = ae->getPlanRepository();
+    PlanRepository* pr = _ae->getPlanRepository();
     for (const std::pair<const int64_t, Plan*>& it : pr->_plans) {
         Plan* p = it.second;
 
-        auto ufGen = utilityCreator->createUtility(p->getId());
+        auto ufGen = _utilityCreator->createUtility(p->getId());
         p->_utilityFunction = ufGen->getUtilityFunction(p);
 
         if (p->getPreCondition() != nullptr) {
             if (p->getPreCondition()->isEnabled()) {
-                p->_preCondition->setBasicCondition(this->conditionCreator->createConditions(p->getPreCondition()->getId()));
+                p->_preCondition->setBasicCondition(this->_conditionCreator->createConditions(p->getPreCondition()->getId()));
                 attachConstraint(p->_preCondition);
             } else {
                 p->_preCondition->setBasicCondition(make_shared<BasicFalseCondition>());
@@ -64,14 +64,14 @@ void ExpressionHandler::attachAll()
         }
 
         if (p->getRuntimeCondition() != nullptr) {
-            p->_runtimeCondition->setBasicCondition(this->conditionCreator->createConditions(p->getRuntimeCondition()->getId()));
+            p->_runtimeCondition->setBasicCondition(this->_conditionCreator->createConditions(p->getRuntimeCondition()->getId()));
             attachConstraint(p->_runtimeCondition);
         }
 
         for (const Transition* t : p->_transitions) {
             if (t->getPreCondition() != nullptr) {
                 if (t->getPreCondition()->isEnabled()) {
-                    t->_preCondition->setBasicCondition(this->conditionCreator->createConditions(t->getPreCondition()->getId()));
+                    t->_preCondition->setBasicCondition(this->_conditionCreator->createConditions(t->getPreCondition()->getId()));
                     attachConstraint(t->_preCondition);
                 } else {
                     t->_preCondition->setBasicCondition(make_shared<BasicFalseCondition>());
@@ -104,7 +104,7 @@ void ExpressionHandler::attachConstraint(Condition* c)
     if (c->getVariables().size() == 0 && c->getQuantifiers().size() == 0) {
         c->setBasicConstraint(make_shared<DummyConstraint>());
     } else {
-        c->setBasicConstraint(this->constraintCreator->createConstraint(c->getId()));
+        c->setBasicConstraint(this->_constraintCreator->createConstraint(c->getId()));
     }
 }
 

--- a/alica_engine/src/engine/expressionhandler/ExpressionHandler.cpp
+++ b/alica_engine/src/engine/expressionhandler/ExpressionHandler.cpp
@@ -30,11 +30,11 @@ namespace alica
  * Constructor, loads the assembly containing expressions and constraints.
  */
 ExpressionHandler::ExpressionHandler(AlicaEngine* ae, IConditionCreator* cc, IUtilityCreator* uc, IConstraintCreator* crc)
+        : _ae(ae)
+        , _conditionCreator(cc)
+        , _utilityCreator(uc)
+        , _constraintCreator(crc)
 {
-    this->_ae = ae;
-    this->_conditionCreator = cc;
-    this->_utilityCreator = uc;
-    this->_constraintCreator = crc;
 }
 
 ExpressionHandler::~ExpressionHandler()
@@ -56,7 +56,7 @@ void ExpressionHandler::attachAll()
 
         if (p->getPreCondition() != nullptr) {
             if (p->getPreCondition()->isEnabled()) {
-                p->_preCondition->setBasicCondition(this->_conditionCreator->createConditions(p->getPreCondition()->getId()));
+                p->_preCondition->setBasicCondition(_conditionCreator->createConditions(p->getPreCondition()->getId()));
                 attachConstraint(p->_preCondition);
             } else {
                 p->_preCondition->setBasicCondition(make_shared<BasicFalseCondition>());
@@ -64,14 +64,14 @@ void ExpressionHandler::attachAll()
         }
 
         if (p->getRuntimeCondition() != nullptr) {
-            p->_runtimeCondition->setBasicCondition(this->_conditionCreator->createConditions(p->getRuntimeCondition()->getId()));
+            p->_runtimeCondition->setBasicCondition(_conditionCreator->createConditions(p->getRuntimeCondition()->getId()));
             attachConstraint(p->_runtimeCondition);
         }
 
         for (const Transition* t : p->_transitions) {
             if (t->getPreCondition() != nullptr) {
                 if (t->getPreCondition()->isEnabled()) {
-                    t->_preCondition->setBasicCondition(this->_conditionCreator->createConditions(t->getPreCondition()->getId()));
+                    t->_preCondition->setBasicCondition(_conditionCreator->createConditions(t->getPreCondition()->getId()));
                     attachConstraint(t->_preCondition);
                 } else {
                     t->_preCondition->setBasicCondition(make_shared<BasicFalseCondition>());
@@ -104,7 +104,7 @@ void ExpressionHandler::attachConstraint(Condition* c)
     if (c->getVariables().size() == 0 && c->getQuantifiers().size() == 0) {
         c->setBasicConstraint(make_shared<DummyConstraint>());
     } else {
-        c->setBasicConstraint(this->_constraintCreator->createConstraint(c->getId()));
+        c->setBasicConstraint(_constraintCreator->createConstraint(c->getId()));
     }
 }
 

--- a/alica_engine/src/engine/parser/ModelFactory.cpp
+++ b/alica_engine/src/engine/parser/ModelFactory.cpp
@@ -92,14 +92,14 @@ const string ModelFactory::alternativePlan = "alternativePlan";
  */
 ModelFactory::ModelFactory(PlanParser* p, PlanRepository* rep)
 {
-    this->parser = p;
-    this->rep = rep;
+    this->_parser = p;
+    this->_rep = rep;
     this->ignoreMasterPlanId = false;
 }
 
 ModelFactory::~ModelFactory()
 {
-    for (auto iter : this->elements) {
+    for (auto iter : this->_elements) {
         delete iter.second;
     }
 }
@@ -118,9 +118,9 @@ Plan* ModelFactory::createPlan(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
 
-    int64_t id = this->parser->parserId(element);
+    int64_t id = this->_parser->parserId(element);
     Plan* plan = new Plan(id);
-    plan->setFileName(this->parser->getCurrentFile());
+    plan->setFileName(this->_parser->getCurrentFile());
     setAlicaElementAttributes(plan, element);
 
     string isMasterPlanAttr = element->Attribute("masterPlan");
@@ -148,7 +148,7 @@ Plan* ModelFactory::createPlan(tinyxml2::XMLDocument* node)
     // insert into elements ma
     addElement(plan);
     // insert into plan repository map
-    this->rep->_plans.emplace(plan->getId(), plan);
+    this->_rep->_plans.emplace(plan->getId(), plan);
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
 
@@ -274,7 +274,7 @@ RoleSet* ModelFactory::createRoleSet(tinyxml2::XMLDocument* node, Plan* masterPl
     }
 
     RoleSet* rs = new RoleSet();
-    rs->setId(this->parser->parserId(element));
+    rs->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(rs, element);
     rs->setIsDefault(isDefault);
     rs->setUsableWithPlanId(pid);
@@ -297,7 +297,7 @@ RoleSet* ModelFactory::createRoleSet(tinyxml2::XMLDocument* node, Plan* masterPl
 RoleTaskMapping* ModelFactory::createRoleTaskMapping(tinyxml2::XMLElement* element)
 {
     RoleTaskMapping* rtm = new RoleTaskMapping();
-    rtm->setId(this->parser->parserId(element));
+    rtm->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(rtm, element);
     addElement(rtm);
 
@@ -312,8 +312,8 @@ RoleTaskMapping* ModelFactory::createRoleTaskMapping(tinyxml2::XMLElement* eleme
                 rtm->_taskPriorities.insert(pair<int64_t, double>(stoll(keyPtr), stod(valuePtr)));
             }
         } else if (role.compare(val) == 0) {
-            int64_t cid = this->parser->parserId(curChild);
-            this->rtmRoleReferences.push_back(pair<int64_t, int64_t>(rtm->getId(), cid));
+            int64_t cid = this->_parser->parserId(curChild);
+            this->_rtmRoleReferences.push_back(pair<int64_t, int64_t>(rtm->getId(), cid));
         } else {
             AlicaEngine::abort("MF: Unhandled RoleTaskMapping Child ", curChild->Value());
         }
@@ -326,7 +326,7 @@ void ModelFactory::createCapabilityDefinitionSet(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
     CapabilityDefinitionSet* capSet = new CapabilityDefinitionSet();
-    capSet->setId(this->parser->parserId(element));
+    capSet->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(capSet, element);
     addElement(capSet);
 
@@ -345,17 +345,17 @@ void ModelFactory::createCapabilityDefinitionSet(tinyxml2::XMLDocument* node)
 Capability* ModelFactory::createCapability(tinyxml2::XMLElement* element)
 {
     Capability* cap = new Capability();
-    cap->setId(this->parser->parserId(element));
+    cap->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(cap, element);
     addElement(cap);
-    this->rep->_capabilities.insert(pair<int64_t, Capability*>(cap->getId(), cap));
+    this->_rep->_capabilities.insert(pair<int64_t, Capability*>(cap->getId(), cap));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
         if (capValues.compare(val) == 0) {
             CapValue* cval = new CapValue();
-            cval->setId(this->parser->parserId(curChild));
+            cval->setId(this->_parser->parserId(curChild));
             setAlicaElementAttributes(cval, curChild);
             addElement(cval);
             cap->_capValues.push_back(cval);
@@ -370,11 +370,11 @@ void ModelFactory::createRoleDefinitionSet(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
     RoleDefinitionSet* r = new RoleDefinitionSet();
-    r->setId(this->parser->parserId(element));
-    r->setFileName(this->parser->getCurrentFile());
+    r->setId(this->_parser->parserId(element));
+    r->setFileName(this->_parser->getCurrentFile());
     setAlicaElementAttributes(r, element);
     addElement(r);
-    this->rep->_roleDefinitionSets.insert(pair<int64_t, RoleDefinitionSet*>(r->getId(), r));
+    this->_rep->_roleDefinitionSets.insert(pair<int64_t, RoleDefinitionSet*>(r->getId(), r));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
@@ -393,10 +393,10 @@ void ModelFactory::createRoleDefinitionSet(tinyxml2::XMLDocument* node)
 Role* ModelFactory::createRole(tinyxml2::XMLElement* element)
 {
     Role* r = new Role();
-    r->setId(this->parser->parserId(element));
+    r->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(r, element);
     addElement(r);
-    this->rep->_roles.insert(pair<int64_t, Role*>(r->getId(), r));
+    this->_rep->_roles.insert(pair<int64_t, Role*>(r->getId(), r));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
@@ -414,7 +414,7 @@ Role* ModelFactory::createRole(tinyxml2::XMLElement* element)
 Characteristic* ModelFactory::createCharacteristic(tinyxml2::XMLElement* element)
 {
     Characteristic* cha = new Characteristic();
-    cha->setId(this->parser->parserId(element));
+    cha->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(cha, element);
     const char* attr = element->Attribute("weight");
     if (attr) {
@@ -422,17 +422,17 @@ Characteristic* ModelFactory::createCharacteristic(tinyxml2::XMLElement* element
     }
 
     addElement(cha);
-    this->rep->_characteristics.insert(pair<int64_t, Characteristic*>(cha->getId(), cha));
+    this->_rep->_characteristics.insert(pair<int64_t, Characteristic*>(cha->getId(), cha));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
         if (capability.compare(val) == 0) {
-            int64_t capid = this->parser->parserId(curChild);
-            this->charCapReferences.push_back(pair<int64_t, int64_t>(cha->getId(), capid));
+            int64_t capid = this->_parser->parserId(curChild);
+            this->_charCapReferences.push_back(pair<int64_t, int64_t>(cha->getId(), capid));
         } else if (value.compare(val) == 0) {
-            int64_t capValid = this->parser->parserId(curChild);
-            this->charCapValReferences.push_back(pair<int64_t, int64_t>(cha->getId(), capValid));
+            int64_t capValid = this->_parser->parserId(curChild);
+            this->_charCapValReferences.push_back(pair<int64_t, int64_t>(cha->getId(), capValid));
         } else {
             AlicaEngine::abort("MF: Unhandled Characteristic Child:", curChild->Value());
         }
@@ -443,20 +443,20 @@ Characteristic* ModelFactory::createCharacteristic(tinyxml2::XMLElement* element
 void ModelFactory::createBehaviour(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
-    int64_t id = this->parser->parserId(element);
+    int64_t id = this->_parser->parserId(element);
     Behaviour* beh = new Behaviour();
     beh->setId(id);
 
     setAlicaElementAttributes(beh, element);
     addElement(beh);
-    this->rep->_behaviours.insert(pair<int64_t, Behaviour*>(beh->getId(), beh));
+    this->_rep->_behaviours.insert(pair<int64_t, Behaviour*>(beh->getId(), beh));
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        this->parser->parserId(curChild);
+        this->_parser->parserId(curChild);
         if (configurations.compare(val) == 0) {
             BehaviourConfiguration* bc = createBehaviourConfiguration(curChild);
-            this->rep->_behaviourConfigurations.insert(pair<int64_t, BehaviourConfiguration*>(bc->getId(), bc));
+            this->_rep->_behaviourConfigurations.insert(pair<int64_t, BehaviourConfiguration*>(bc->getId(), bc));
             bc->setBehaviour(beh);
             beh->_configurations.push_back(bc);
         } else {
@@ -468,8 +468,8 @@ void ModelFactory::createBehaviour(tinyxml2::XMLDocument* node)
 BehaviourConfiguration* ModelFactory::createBehaviourConfiguration(tinyxml2::XMLElement* element)
 {
     BehaviourConfiguration* b = new BehaviourConfiguration();
-    b->setId(this->parser->parserId(element));
-    b->setFileName(this->parser->getCurrentFile());
+    b->setId(this->_parser->parserId(element));
+    b->setFileName(this->_parser->getCurrentFile());
 
     const char* attr = element->Attribute("masterPlan");
     string attrString = "";
@@ -514,11 +514,11 @@ BehaviourConfiguration* ModelFactory::createBehaviourConfiguration(tinyxml2::XML
         b->setFrequency(stoi(attr));
     }
     setAlicaElementAttributes(b, element);
-    this->elements.insert(pair<int64_t, AlicaElement*>(b->getId(), b));
+    this->_elements.insert(pair<int64_t, AlicaElement*>(b->getId(), b));
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        this->parser->parserId(curChild);
+        this->_parser->parserId(curChild);
         if (vars.compare(val) == 0) {
             Variable* v = createVariable(curChild);
             b->_variables.push_back(v);
@@ -540,11 +540,11 @@ void ModelFactory::createPlanType(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
     PlanType* pt = new PlanType();
-    pt->setId(this->parser->parserId(element));
-    pt->setFileName(this->parser->getCurrentFile());
+    pt->setId(this->_parser->parserId(element));
+    pt->setFileName(this->_parser->getCurrentFile());
     setAlicaElementAttributes(pt, element);
     addElement(pt);
-    this->rep->_planTypes.insert(pair<int64_t, PlanType*>(pt->getId(), pt));
+    this->_rep->_planTypes.insert(pair<int64_t, PlanType*>(pt->getId(), pt));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
@@ -556,8 +556,8 @@ void ModelFactory::createPlanType(tinyxml2::XMLDocument* node)
                 activated = activatedPtr;
                 transform(activated.begin(), activated.end(), activated.begin(), ::tolower);
                 if (activated.compare("true") == 0) {
-                    int64_t cid = this->parser->parserId(curChild->FirstChildElement());
-                    this->planTypePlanReferences.push_back(pair<int64_t, int64_t>(pt->getId(), cid));
+                    int64_t cid = this->_parser->parserId(curChild->FirstChildElement());
+                    this->_planTypePlanReferences.push_back(pair<int64_t, int64_t>(pt->getId(), cid));
                 }
             } else {
 #ifdef PP_DEBUG
@@ -581,11 +581,11 @@ void ModelFactory::createTasks(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
     TaskRepository* tr = new TaskRepository();
-    tr->setId(this->parser->parserId(element));
-    tr->setFileName(this->parser->getCurrentFile());
+    tr->setId(this->_parser->parserId(element));
+    tr->setFileName(this->_parser->getCurrentFile());
     addElement(tr);
     setAlicaElementAttributes(tr, element);
-    this->rep->_taskRepositories.insert(pair<int64_t, TaskRepository*>(tr->getId(), tr));
+    this->_rep->_taskRepositories.insert(pair<int64_t, TaskRepository*>(tr->getId(), tr));
     int64_t id = 0;
     const char* defaultTaskPtr = element->Attribute("defaultTask");
     if (defaultTaskPtr) {
@@ -595,7 +595,7 @@ void ModelFactory::createTasks(tinyxml2::XMLDocument* node)
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
-        int64_t cid = this->parser->parserId(curChild);
+        int64_t cid = this->_parser->parserId(curChild);
 
         Task* task = new Task(cid == id);
         task->setId(cid);
@@ -606,7 +606,7 @@ void ModelFactory::createTasks(tinyxml2::XMLDocument* node)
             task->setDescription(descriptionkPtr);
         }
         addElement(task);
-        this->rep->_tasks.insert(pair<int64_t, Task*>(task->getId(), task));
+        this->_rep->_tasks.insert(pair<int64_t, Task*>(task->getId(), task));
         task->setTaskRepository(tr);
         tr->_tasks.push_back(task);
         curChild = curChild->NextSiblingElement();
@@ -616,7 +616,7 @@ void ModelFactory::createTasks(tinyxml2::XMLDocument* node)
 SyncTransition* ModelFactory::createSyncTransition(tinyxml2::XMLElement* element)
 {
     SyncTransition* s = new SyncTransition();
-    s->setId(this->parser->parserId(element));
+    s->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(s, element);
     const char* talkTimeoutPtr = element->Attribute("talkTimeout");
     if (talkTimeoutPtr) {
@@ -628,7 +628,7 @@ SyncTransition* ModelFactory::createSyncTransition(tinyxml2::XMLElement* element
     }
 
     addElement(s);
-    this->rep->_syncTransitions.insert(pair<int64_t, SyncTransition*>(s->getId(), s));
+    this->_rep->_syncTransitions.insert(pair<int64_t, SyncTransition*>(s->getId(), s));
     if (element->FirstChild()) {
         AlicaEngine::abort("MF: Unhandled Synchtransition Child:", element->FirstChild());
     }
@@ -646,15 +646,15 @@ Variable* ModelFactory::createVariable(tinyxml2::XMLElement* element)
     if (namePtr) {
         name = namePtr;
     }
-    Variable* v = new Variable(this->parser->parserId(element), name, type);
+    Variable* v = new Variable(this->_parser->parserId(element), name, type);
     setAlicaElementAttributes(v, element);
     addElement(v);
-    this->rep->_variables.insert(pair<int64_t, Variable*>(v->getId(), v));
+    this->_rep->_variables.insert(pair<int64_t, Variable*>(v->getId(), v));
     return v;
 }
 RuntimeCondition* ModelFactory::createRuntimeCondition(tinyxml2::XMLElement* element)
 {
-    RuntimeCondition* r = new RuntimeCondition(this->parser->parserId(element));
+    RuntimeCondition* r = new RuntimeCondition(this->_parser->parserId(element));
     setAlicaElementAttributes(r, element);
     addElement(r);
 
@@ -679,9 +679,9 @@ RuntimeCondition* ModelFactory::createRuntimeCondition(tinyxml2::XMLElement* ele
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->parser->parserId(curChild);
+        int64_t cid = this->_parser->parserId(curChild);
         if (vars.compare(val) == 0) {
-            this->conditionVarReferences.push_back(pair<int64_t, int64_t>(r->getId(), cid));
+            this->_conditionVarReferences.push_back(pair<int64_t, int64_t>(r->getId(), cid));
         } else if (quantifiers.compare(val) == 0) {
             Quantifier* q = createQuantifier(curChild);
             r->_quantifiers.push_back(q);
@@ -700,8 +700,8 @@ void ModelFactory::createPlanningProblem(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
     PlanningProblem* p = new PlanningProblem();
-    p->setId(this->parser->parserId(element));
-    p->setFileName(this->parser->getCurrentFile());
+    p->setId(this->_parser->parserId(element));
+    p->setFileName(this->_parser->getCurrentFile());
     setAlicaElementAttributes(p, element);
     addElement(p);
 
@@ -747,14 +747,14 @@ void ModelFactory::createPlanningProblem(tinyxml2::XMLDocument* node)
         p->setRequirements("");
     }
 
-    this->rep->_planningProblems.insert(pair<int64_t, PlanningProblem*>(p->getId(), p));
+    this->_rep->_planningProblems.insert(pair<int64_t, PlanningProblem*>(p->getId(), p));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->parser->parserId(curChild);
+        int64_t cid = this->_parser->parserId(curChild);
         if (plans.compare(val) == 0) {
-            this->planningProblemPlanReferences.push_back(pair<int64_t, int64_t>(p->getId(), cid));
+            this->_planningProblemPlanReferences.push_back(pair<int64_t, int64_t>(p->getId(), cid));
         } else if (conditions.compare(val) == 0) {
             const char* type = curChild->Attribute("xsi:type");
             string typeStr;
@@ -774,9 +774,9 @@ void ModelFactory::createPlanningProblem(tinyxml2::XMLDocument* node)
                 AlicaEngine::abort("MF: Unknown Condition type:", curChild->Value());
             }
         } else if (waitPlan.compare(val) == 0) {
-            this->planningProblemPlanWaitReferences.push_back(pair<int64_t, int64_t>(p->getId(), cid));
+            this->_planningProblemPlanWaitReferences.push_back(pair<int64_t, int64_t>(p->getId(), cid));
         } else if (alternativePlan.compare(val) == 0) {
-            this->planningProblemPlanAlternativeReferences.push_back(pair<int64_t, int64_t>(p->getId(), cid));
+            this->_planningProblemPlanAlternativeReferences.push_back(pair<int64_t, int64_t>(p->getId(), cid));
         }
 
         curChild = curChild->NextSiblingElement();
@@ -786,24 +786,24 @@ void ModelFactory::createPlanningProblem(tinyxml2::XMLDocument* node)
 Transition* ModelFactory::createTransition(tinyxml2::XMLElement* element, Plan* plan)
 {
     Transition* tran = new Transition();
-    tran->setId(this->parser->parserId(element));
+    tran->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(tran, element);
     addElement(tran);
-    this->rep->_transitions.insert(pair<int64_t, Transition*>(tran->getId(), tran));
+    this->_rep->_transitions.insert(pair<int64_t, Transition*>(tran->getId(), tran));
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->parser->parserId(curChild);
+        int64_t cid = this->_parser->parserId(curChild);
         if (inState.compare(val) == 0) {
             // silently ignore
         } else if (outState.compare(val) == 0) {
-            this->transitionAimReferences.push_back(pair<int64_t, int64_t>(tran->getId(), cid));
+            this->_transitionAimReferences.push_back(pair<int64_t, int64_t>(tran->getId(), cid));
         } else if (preCondition.compare(val) == 0) {
             PreCondition* pre = createPreCondition(curChild);
             tran->setPreCondition(pre);
             pre->setAbstractPlan(plan);
         } else if (synchronisation.compare(val) == 0) {
-            this->transitionSynchReferences.push_back(pair<int64_t, int64_t>(tran->getId(), cid));
+            this->_transitionSynchReferences.push_back(pair<int64_t, int64_t>(tran->getId(), cid));
         } else {
             AlicaEngine::abort("MF: Unhandled Transition Child:", curChild);
         }
@@ -815,7 +815,7 @@ Transition* ModelFactory::createTransition(tinyxml2::XMLElement* element, Plan* 
 PreCondition* ModelFactory::createPreCondition(tinyxml2::XMLElement* element)
 {
     PreCondition* pre = new PreCondition();
-    pre->setId(this->parser->parserId(element));
+    pre->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(pre, element);
     addElement(pre);
     string conditionString = "";
@@ -852,9 +852,9 @@ PreCondition* ModelFactory::createPreCondition(tinyxml2::XMLElement* element)
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->parser->parserId(curChild);
+        int64_t cid = this->_parser->parserId(curChild);
         if (vars.compare(val) == 0) {
-            this->conditionVarReferences.push_back(pair<int64_t, int64_t>(pre->getId(), cid));
+            this->_conditionVarReferences.push_back(pair<int64_t, int64_t>(pre->getId(), cid));
         } else if (quantifiers.compare(val) == 0) {
             Quantifier* q = createQuantifier(curChild);
             pre->_quantifiers.push_back(q);
@@ -872,7 +872,7 @@ PreCondition* ModelFactory::createPreCondition(tinyxml2::XMLElement* element)
 Parameter* ModelFactory::createParameter(tinyxml2::XMLElement* element)
 {
     Parameter* p = new Parameter();
-    int64_t id = this->parser->parserId(element);
+    int64_t id = this->_parser->parserId(element);
     p->setId(id);
     addElement(p);
     setAlicaElementAttributes(p, element);
@@ -886,7 +886,7 @@ Parameter* ModelFactory::createParameter(tinyxml2::XMLElement* element)
 Quantifier* ModelFactory::createQuantifier(tinyxml2::XMLElement* element)
 {
     Quantifier* q;
-    int64_t id = this->parser->parserId(element);
+    int64_t id = this->_parser->parserId(element);
 
     string typeString = "";
     const char* typePtr = element->Attribute("xsi:type");
@@ -903,14 +903,14 @@ Quantifier* ModelFactory::createQuantifier(tinyxml2::XMLElement* element)
     }
 
     addElement(q);
-    this->rep->_quantifiers.insert(pair<int64_t, Quantifier*>(q->getId(), q));
+    this->_rep->_quantifiers.insert(pair<int64_t, Quantifier*>(q->getId(), q));
     setAlicaElementAttributes(q, element);
 
     const char* scopePtr = element->Attribute("scope");
     int64_t cid;
     if (scopePtr) {
         cid = stoll(scopePtr);
-        this->quantifierScopeReferences.push_back(pair<int64_t, int64_t>(q->getId(), cid));
+        this->_quantifierScopeReferences.push_back(pair<int64_t, int64_t>(q->getId(), cid));
     }
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
@@ -930,18 +930,18 @@ Quantifier* ModelFactory::createQuantifier(tinyxml2::XMLElement* element)
 FailureState* ModelFactory::createFailureState(tinyxml2::XMLElement* element)
 {
     FailureState* fail = new FailureState();
-    fail->setId(this->parser->parserId(element));
+    fail->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(fail, element);
 
     addElement(fail);
-    this->rep->_states.insert(pair<int64_t, State*>(fail->getId(), fail));
+    this->_rep->_states.insert(pair<int64_t, State*>(fail->getId(), fail));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->parser->parserId(curChild);
+        int64_t cid = this->_parser->parserId(curChild);
         if (inTransitions.compare(val) == 0) {
-            this->stateInTransitionReferences.push_back(pair<int64_t, int64_t>(fail->getId(), cid));
+            this->_stateInTransitionReferences.push_back(pair<int64_t, int64_t>(fail->getId(), cid));
         } else if (postCondition.compare(val) == 0) {
             PostCondition* postCon = createPostCondition(curChild);
             fail->setPostCondition(postCon);
@@ -956,18 +956,18 @@ FailureState* ModelFactory::createFailureState(tinyxml2::XMLElement* element)
 SuccessState* ModelFactory::createSuccessState(tinyxml2::XMLElement* element)
 {
     SuccessState* suc = new SuccessState();
-    suc->setId(this->parser->parserId(element));
+    suc->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(suc, element);
 
     addElement(suc);
-    this->rep->_states.insert(pair<int64_t, State*>(suc->getId(), suc));
+    this->_rep->_states.insert(pair<int64_t, State*>(suc->getId(), suc));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->parser->parserId(curChild);
+        int64_t cid = this->_parser->parserId(curChild);
         if (inTransitions.compare(val) == 0) {
-            this->stateInTransitionReferences.push_back(pair<int64_t, int64_t>(suc->getId(), cid));
+            this->_stateInTransitionReferences.push_back(pair<int64_t, int64_t>(suc->getId(), cid));
         } else if (postCondition.compare(val) == 0) {
             PostCondition* postCon = createPostCondition(curChild);
             suc->setPostCondition(postCon);
@@ -982,7 +982,7 @@ SuccessState* ModelFactory::createSuccessState(tinyxml2::XMLElement* element)
 PostCondition* ModelFactory::createPostCondition(tinyxml2::XMLElement* element)
 {
     PostCondition* pos = new PostCondition();
-    pos->setId(this->parser->parserId(element));
+    pos->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(pos, element);
     addElement(pos);
 
@@ -1014,7 +1014,7 @@ PostCondition* ModelFactory::createPostCondition(tinyxml2::XMLElement* element)
 EntryPoint* ModelFactory::createEntryPoint(tinyxml2::XMLElement* element)
 {
     EntryPoint* ep = new EntryPoint();
-    ep->setId(this->parser->parserId(element));
+    ep->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(ep, element);
     string attr = element->Attribute("minCardinality");
     if (!attr.empty()) {
@@ -1031,20 +1031,20 @@ EntryPoint* ModelFactory::createEntryPoint(tinyxml2::XMLElement* element)
     }
 
     addElement(ep);
-    this->rep->_entryPoints.insert(pair<int64_t, EntryPoint*>(ep->getId(), ep));
+    this->_rep->_entryPoints.insert(pair<int64_t, EntryPoint*>(ep->getId(), ep));
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     bool haveState = false;
     int64_t curChildId;
 
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        curChildId = this->parser->parserId(curChild);
+        curChildId = this->_parser->parserId(curChild);
 
         if (state.compare(val) == 0) {
-            this->epStateReferences.push_back(pair<int64_t, int64_t>(ep->getId(), curChildId));
+            this->_epStateReferences.push_back(pair<int64_t, int64_t>(ep->getId(), curChildId));
             haveState = true;
         } else if (task.compare(val) == 0) {
-            this->epTaskReferences.push_back(pair<int64_t, int64_t>(ep->getId(), curChildId));
+            this->_epTaskReferences.push_back(pair<int64_t, int64_t>(ep->getId(), curChildId));
         } else {
             AlicaEngine::abort("MF: Unhandled EntryPoint Child: ", val);
         }
@@ -1065,22 +1065,22 @@ EntryPoint* ModelFactory::createEntryPoint(tinyxml2::XMLElement* element)
 State* ModelFactory::createState(tinyxml2::XMLElement* element)
 {
     State* s = new State();
-    s->setId(this->parser->parserId(element));
+    s->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(s, element);
 
     addElement(s);
-    this->rep->_states.insert(pair<int64_t, State*>(s->getId(), s));
+    this->_rep->_states.insert(pair<int64_t, State*>(s->getId(), s));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->parser->parserId(curChild);
+        int64_t cid = this->_parser->parserId(curChild);
         if (inTransitions.compare(val) == 0) {
-            this->stateInTransitionReferences.push_back(pair<int64_t, int64_t>(s->getId(), cid));
+            this->_stateInTransitionReferences.push_back(pair<int64_t, int64_t>(s->getId(), cid));
         } else if (outTransitions.compare(val) == 0) {
-            this->stateOutTransitionReferences.push_back(pair<int64_t, int64_t>(s->getId(), cid));
+            this->_stateOutTransitionReferences.push_back(pair<int64_t, int64_t>(s->getId(), cid));
         } else if (plans.compare(val) == 0) {
-            this->statePlanReferences.push_back(pair<int64_t, int64_t>(s->getId(), cid));
+            this->_statePlanReferences.push_back(pair<int64_t, int64_t>(s->getId(), cid));
         } else if (parametrisation.compare(val) == 0) {
             Parametrisation* para = createParametrisation(curChild);
             s->_parametrisation.push_back(para);
@@ -1096,20 +1096,20 @@ State* ModelFactory::createState(tinyxml2::XMLElement* element)
 Parametrisation* ModelFactory::createParametrisation(tinyxml2::XMLElement* element)
 {
     Parametrisation* para = new Parametrisation();
-    para->setId(this->parser->parserId(element));
+    para->setId(this->_parser->parserId(element));
     setAlicaElementAttributes(para, element);
 
     addElement(para);
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->parser->parserId(curChild);
+        int64_t cid = this->_parser->parserId(curChild);
         if (subplan.compare(val) == 0) {
-            this->paramSubPlanReferences.push_back(pair<int64_t, int64_t>(para->getId(), cid));
+            this->_paramSubPlanReferences.push_back(pair<int64_t, int64_t>(para->getId(), cid));
         } else if (subvar.compare(val) == 0) {
-            this->paramSubVarReferences.push_back(pair<int64_t, int64_t>(para->getId(), cid));
+            this->_paramSubVarReferences.push_back(pair<int64_t, int64_t>(para->getId(), cid));
         } else if (var.compare(val) == 0) {
-            this->paramVarReferences.push_back(pair<int64_t, int64_t>(para->getId(), cid));
+            this->_paramVarReferences.push_back(pair<int64_t, int64_t>(para->getId(), cid));
         } else {
             AlicaEngine::abort("MF: Unhandled Parametrisation Child:", curChild);
         }
@@ -1174,11 +1174,11 @@ void ModelFactory::computeReachabilities()
 #ifdef MF_DEBUG
     cout << "MF: Computing Reachability sets..." << endl;
 #endif
-    for (const std::pair<const int64_t, EntryPoint*>& ep : rep->_entryPoints) {
+    for (const std::pair<const int64_t, EntryPoint*>& ep : _rep->_entryPoints) {
         ep.second->computeReachabilitySet();
         // set backpointers:
         for (const State* s : ep.second->_reachableStates) {
-            rep->_states[s->getId()]->_entryPoint = ep.second;
+            _rep->_states[s->getId()]->_entryPoint = ep.second;
         }
     }
 
@@ -1192,140 +1192,140 @@ void ModelFactory::attachPlanReferences()
     cout << "MF: Attaching Plan references.." << endl;
 #endif
     // epTaskReferences
-    for (pair<int64_t, int64_t> pairs : this->epTaskReferences) {
-        Task* t = (Task*) this->elements.find(pairs.second)->second;
-        EntryPoint* ep = (EntryPoint*) this->elements.find(pairs.first)->second;
+    for (pair<int64_t, int64_t> pairs : this->_epTaskReferences) {
+        Task* t = (Task*) this->_elements.find(pairs.second)->second;
+        EntryPoint* ep = (EntryPoint*) this->_elements.find(pairs.first)->second;
         ep->setTask(t);
     }
-    this->epTaskReferences.clear();
+    this->_epTaskReferences.clear();
 
     // transitionAimReferences
-    for (pair<int64_t, int64_t> pairs : this->transitionAimReferences) {
-        Transition* t = (Transition*) this->elements.find(pairs.first)->second;
-        State* st = (State*) this->elements.find(pairs.second)->second;
+    for (pair<int64_t, int64_t> pairs : this->_transitionAimReferences) {
+        Transition* t = (Transition*) this->_elements.find(pairs.first)->second;
+        State* st = (State*) this->_elements.find(pairs.second)->second;
         if (!st) {
             AlicaEngine::abort("MF: Cannot resolve transitionAimReferences target: ", pairs.first);
         }
         t->setOutState(st);
         st->_inTransitions.push_back(t);
     }
-    this->transitionAimReferences.clear();
+    this->_transitionAimReferences.clear();
 
     // epStateReferences
-    for (std::pair<int64_t, int64_t> pairs : this->epStateReferences) {
-        State* st = (State*) this->elements.find(pairs.second)->second;
-        EntryPoint* ep = (EntryPoint*) this->elements.find(pairs.first)->second;
+    for (std::pair<int64_t, int64_t> pairs : this->_epStateReferences) {
+        State* st = (State*) this->_elements.find(pairs.second)->second;
+        EntryPoint* ep = (EntryPoint*) this->_elements.find(pairs.first)->second;
         ep->setState(st); // back reference will be set later
     }
-    this->epStateReferences.clear();
+    this->_epStateReferences.clear();
 
     // stateInTransitionReferences
-    for (pair<int64_t, int64_t> pairs : this->stateInTransitionReferences) {
-        Transition* t = (Transition*) this->elements.find(pairs.second)->second;
-        State* st = (State*) this->elements.find(pairs.first)->second;
+    for (pair<int64_t, int64_t> pairs : this->_stateInTransitionReferences) {
+        Transition* t = (Transition*) this->_elements.find(pairs.second)->second;
+        State* st = (State*) this->_elements.find(pairs.first)->second;
         if (st != t->getOutState()) {
             AlicaEngine::abort("MF: Unexpected reference in a transition! ", pairs.first);
         }
     }
-    this->stateInTransitionReferences.clear();
+    this->_stateInTransitionReferences.clear();
 
     // stateOutTransitionReferences
-    for (pair<int64_t, int64_t> pairs : this->stateOutTransitionReferences) {
-        State* st = (State*) this->elements.find(pairs.first)->second;
-        Transition* t = (Transition*) this->elements.find(pairs.second)->second;
+    for (pair<int64_t, int64_t> pairs : this->_stateOutTransitionReferences) {
+        State* st = (State*) this->_elements.find(pairs.first)->second;
+        Transition* t = (Transition*) this->_elements.find(pairs.second)->second;
         st->_outTransitions.push_back(t);
         t->setInState(st);
     }
-    this->stateOutTransitionReferences.clear();
+    this->_stateOutTransitionReferences.clear();
 
     // statePlanReferences
-    for (pair<int64_t, int64_t> pairs : this->statePlanReferences) {
-        State* st = (State*) this->elements.find(pairs.first)->second;
-        AbstractPlan* p = (AbstractPlan*) this->elements.find(pairs.second)->second;
+    for (pair<int64_t, int64_t> pairs : this->_statePlanReferences) {
+        State* st = (State*) this->_elements.find(pairs.first)->second;
+        AbstractPlan* p = (AbstractPlan*) this->_elements.find(pairs.second)->second;
         st->_plans.push_back(p);
     }
-    this->statePlanReferences.clear();
+    this->_statePlanReferences.clear();
 
     // planTypePlanReferences
-    for (pair<int64_t, int64_t> pairs : this->planTypePlanReferences) {
-        PlanType* pt = (PlanType*) this->elements.find(pairs.first)->second;
-        Plan* p = (Plan*) this->elements.find(pairs.second)->second;
+    for (pair<int64_t, int64_t> pairs : this->_planTypePlanReferences) {
+        PlanType* pt = (PlanType*) this->_elements.find(pairs.first)->second;
+        Plan* p = (Plan*) this->_elements.find(pairs.second)->second;
         pt->_plans.push_back(p);
     }
-    this->planTypePlanReferences.clear();
+    this->_planTypePlanReferences.clear();
 
     // conditionVarReferences
-    for (pair<int64_t, int64_t> pairs : this->conditionVarReferences) {
-        Condition* c = (Condition*) this->elements.find(pairs.first)->second;
-        Variable* v = (Variable*) this->elements.find(pairs.second)->second;
+    for (pair<int64_t, int64_t> pairs : this->_conditionVarReferences) {
+        Condition* c = (Condition*) this->_elements.find(pairs.first)->second;
+        Variable* v = (Variable*) this->_elements.find(pairs.second)->second;
         c->_variables.push_back(v);
     }
-    this->conditionVarReferences.clear();
+    this->_conditionVarReferences.clear();
 
     // paramSubPlanReferences
-    for (pair<int64_t, int64_t> pairs : this->paramSubPlanReferences) {
-        Parametrisation* p = (Parametrisation*) this->elements.find(pairs.first)->second;
-        AbstractPlan* ap = (AbstractPlan*) this->elements.find(pairs.second)->second;
+    for (pair<int64_t, int64_t> pairs : this->_paramSubPlanReferences) {
+        Parametrisation* p = (Parametrisation*) this->_elements.find(pairs.first)->second;
+        AbstractPlan* ap = (AbstractPlan*) this->_elements.find(pairs.second)->second;
         p->setSubPlan(ap);
     }
-    this->paramSubPlanReferences.clear();
+    this->_paramSubPlanReferences.clear();
 
     // paramSubVarReferences
-    for (pair<int64_t, int64_t> pairs : this->paramSubVarReferences) {
-        Parametrisation* p = (Parametrisation*) this->elements.find(pairs.first)->second;
-        Variable* ap = (Variable*) this->elements.find(pairs.second)->second;
+    for (pair<int64_t, int64_t> pairs : this->_paramSubVarReferences) {
+        Parametrisation* p = (Parametrisation*) this->_elements.find(pairs.first)->second;
+        Variable* ap = (Variable*) this->_elements.find(pairs.second)->second;
         p->setSubVar(ap);
     }
-    this->paramSubVarReferences.clear();
+    this->_paramSubVarReferences.clear();
 
     // paramVarReferences
-    for (pair<int64_t, int64_t> pairs : this->paramVarReferences) {
-        Parametrisation* p = (Parametrisation*) this->elements.find(pairs.first)->second;
-        Variable* v = (Variable*) this->elements.find(pairs.second)->second;
+    for (pair<int64_t, int64_t> pairs : this->_paramVarReferences) {
+        Parametrisation* p = (Parametrisation*) this->_elements.find(pairs.first)->second;
+        Variable* v = (Variable*) this->_elements.find(pairs.second)->second;
         p->setVar(v);
     }
-    this->paramVarReferences.clear();
+    this->_paramVarReferences.clear();
 
     // transitionSynchReferences
-    for (pair<int64_t, int64_t> pairs : this->transitionSynchReferences) {
-        Transition* t = (Transition*) this->elements.find(pairs.first)->second;
-        SyncTransition* sync = (SyncTransition*) this->elements.find(pairs.second)->second;
+    for (pair<int64_t, int64_t> pairs : this->_transitionSynchReferences) {
+        Transition* t = (Transition*) this->_elements.find(pairs.first)->second;
+        SyncTransition* sync = (SyncTransition*) this->_elements.find(pairs.second)->second;
         t->setSyncTransition(sync);
         sync->_inSync.push_back(t);
     }
-    this->transitionSynchReferences.clear();
+    this->_transitionSynchReferences.clear();
 
     // planningProblemPlanReferences
-    for (pair<int64_t, int64_t> pairs : this->planningProblemPlanReferences) {
-        PlanningProblem* s = (PlanningProblem*) this->elements.find(pairs.first)->second;
-        AbstractPlan* p = (AbstractPlan*) this->elements.find(pairs.second)->second;
+    for (pair<int64_t, int64_t> pairs : this->_planningProblemPlanReferences) {
+        PlanningProblem* s = (PlanningProblem*) this->_elements.find(pairs.first)->second;
+        AbstractPlan* p = (AbstractPlan*) this->_elements.find(pairs.second)->second;
         s->_plans.push_back(p);
     }
-    this->planningProblemPlanReferences.clear();
+    this->_planningProblemPlanReferences.clear();
 
     // planningProblemPlanWaitReferences
-    for (pair<int64_t, int64_t> pairs : this->planningProblemPlanWaitReferences) {
-        PlanningProblem* s = (PlanningProblem*) this->elements.find(pairs.first)->second;
-        Plan* p = (Plan*) this->elements.find(pairs.second)->second;
+    for (pair<int64_t, int64_t> pairs : this->_planningProblemPlanWaitReferences) {
+        PlanningProblem* s = (PlanningProblem*) this->_elements.find(pairs.first)->second;
+        Plan* p = (Plan*) this->_elements.find(pairs.second)->second;
         s->setWaitPlan(p);
     }
-    this->planningProblemPlanWaitReferences.clear();
+    this->_planningProblemPlanWaitReferences.clear();
 
     // planningProblemPlanAlternativeReferences
-    for (pair<int64_t, int64_t> pairs : this->planningProblemPlanAlternativeReferences) {
-        PlanningProblem* s = (PlanningProblem*) this->elements.find(pairs.first)->second;
-        Plan* p = (Plan*) this->elements.find(pairs.second)->second;
+    for (pair<int64_t, int64_t> pairs : this->_planningProblemPlanAlternativeReferences) {
+        PlanningProblem* s = (PlanningProblem*) this->_elements.find(pairs.first)->second;
+        Plan* p = (Plan*) this->_elements.find(pairs.second)->second;
         s->setAlternativePlan(p);
     }
-    this->planningProblemPlanAlternativeReferences.clear();
+    this->_planningProblemPlanAlternativeReferences.clear();
 
     // quantifierScopeReferences
-    for (pair<int64_t, int64_t> pairs : this->quantifierScopeReferences) {
-        AlicaElement* ael = (AlicaElement*) this->elements.find(pairs.second)->second;
-        Quantifier* q = (Quantifier*) this->elements.find(pairs.first)->second;
+    for (pair<int64_t, int64_t> pairs : this->_quantifierScopeReferences) {
+        AlicaElement* ael = (AlicaElement*) this->_elements.find(pairs.second)->second;
+        Quantifier* q = (Quantifier*) this->_elements.find(pairs.first)->second;
         q->setScope(ael);
     }
-    this->quantifierScopeReferences.clear();
+    this->_quantifierScopeReferences.clear();
 
     createVariableTemplates();
     removeRedundancy();
@@ -1338,13 +1338,13 @@ void ModelFactory::attachRoleReferences()
 #ifdef MF_DEBUG
     cout << "MF: Attaching Role references..." << endl;
 #endif
-    for (pair<int64_t, int64_t> pairs : this->rtmRoleReferences) {
-        Role* r = this->rep->_roles.find(pairs.second)->second;
-        RoleTaskMapping* rtm = static_cast<RoleTaskMapping*>(this->elements.find(pairs.first)->second);
+    for (pair<int64_t, int64_t> pairs : this->_rtmRoleReferences) {
+        Role* r = this->_rep->_roles.find(pairs.second)->second;
+        RoleTaskMapping* rtm = static_cast<RoleTaskMapping*>(this->_elements.find(pairs.first)->second);
         r->setRoleTaskMapping(rtm);
         rtm->setRole(r);
     }
-    this->rtmRoleReferences.clear();
+    this->_rtmRoleReferences.clear();
 #ifdef MF_DEBUG
     cout << "MF: Attaching Role references... done!" << endl;
 #endif
@@ -1354,19 +1354,19 @@ void ModelFactory::attachCharacteristicReferences()
 #ifdef MF_DEBUG
     cout << "MF: Attaching Characteristics references..." << endl;
 #endif
-    for (pair<int64_t, int64_t> pairs : this->charCapReferences) {
-        Characteristic* cha = this->rep->_characteristics.find(pairs.first)->second;
-        Capability* cap = static_cast<Capability*>(this->elements.find(pairs.second)->second);
+    for (pair<int64_t, int64_t> pairs : this->_charCapReferences) {
+        Characteristic* cha = this->_rep->_characteristics.find(pairs.first)->second;
+        Capability* cap = static_cast<Capability*>(this->_elements.find(pairs.second)->second);
         cha->setCapability(cap);
     }
-    this->charCapReferences.clear();
+    this->_charCapReferences.clear();
 
-    for (pair<int64_t, int64_t> pairs : this->charCapValReferences) {
-        Characteristic* cha = this->rep->_characteristics.find(pairs.first)->second;
-        CapValue* capVal = static_cast<CapValue*>(this->elements.find(pairs.second)->second);
+    for (pair<int64_t, int64_t> pairs : this->_charCapValReferences) {
+        Characteristic* cha = this->_rep->_characteristics.find(pairs.first)->second;
+        CapValue* capVal = static_cast<CapValue*>(this->_elements.find(pairs.second)->second);
         cha->setCapValue(capVal);
     }
-    this->charCapValReferences.clear();
+    this->_charCapValReferences.clear();
 #ifdef MF_DEBUG
     cout << "MF: Attaching Characteristics references... done!" << endl;
 #endif
@@ -1374,17 +1374,17 @@ void ModelFactory::attachCharacteristicReferences()
 
 void ModelFactory::createVariableTemplates()
 {
-    for (std::pair<const int64_t, Quantifier*> p : rep->_quantifiers) {
+    for (std::pair<const int64_t, Quantifier*> p : _rep->_quantifiers) {
         Quantifier* q = p.second;
         for (const std::string& s : q->getDomainIdentifiers()) {
             int64_t id = Hash64(s.c_str(), s.size());
             Variable* v;
-            PlanRepository::MapType<Variable>::iterator vit = rep->_variables.find(id);
-            if (vit != rep->_variables.end()) {
+            PlanRepository::MapType<Variable>::iterator vit = _rep->_variables.find(id);
+            if (vit != _rep->_variables.end()) {
                 v = vit->second;
             } else {
                 v = new Variable(id, s, "Template");
-                rep->_variables.emplace(id, v);
+                _rep->_variables.emplace(id, v);
             }
             q->_templateVars.push_back(v);
         }
@@ -1393,7 +1393,7 @@ void ModelFactory::createVariableTemplates()
 
 void ModelFactory::removeRedundancy()
 {
-    for (PlanRepository::MapType<Plan>::iterator iter = rep->_plans.begin(); iter != rep->_plans.end(); ++iter) {
+    for (PlanRepository::MapType<Plan>::iterator iter = _rep->_plans.begin(); iter != _rep->_plans.end(); ++iter) {
         Plan* plan = iter->second;
         for (int i = plan->getTransitions().size() - 1; i >= 0; --i) {
             const Transition* trans = plan->getTransitions()[i];
@@ -1406,24 +1406,24 @@ void ModelFactory::removeRedundancy()
 
 map<int64_t, AlicaElement*>* ModelFactory::getElements()
 {
-    return &this->elements;
+    return &this->_elements;
 }
 
 void ModelFactory::setElements(const map<int64_t, AlicaElement*>& elements)
 {
-    this->elements = elements;
+    this->_elements = elements;
 }
 
 void ModelFactory::addElement(AlicaElement* ael)
 {
-    if (this->elements.find(ael->getId()) != this->elements.end()) {
-        cout << "ELEMENT >" << ael->getName() << "< >" << this->elements[ael->getId()]->getName() << "<" << endl;
+    if (this->_elements.find(ael->getId()) != this->_elements.end()) {
+        cout << "ELEMENT >" << ael->getName() << "< >" << this->_elements[ael->getId()]->getName() << "<" << endl;
         stringstream ss;
         ss << "MF: ERROR Double IDs: " << ael->getId();
         cout << segfaultdebug::get_stacktrace() << endl;
         AlicaEngine::abort(ss.str());
     }
-    elements.insert(pair<int64_t, AlicaElement*>(ael->getId(), ael));
+    _elements.insert(pair<int64_t, AlicaElement*>(ael->getId(), ael));
 }
 
 const EntryPoint* ModelFactory::generateIdleEntryPoint()

--- a/alica_engine/src/engine/parser/ModelFactory.cpp
+++ b/alica_engine/src/engine/parser/ModelFactory.cpp
@@ -92,35 +92,35 @@ const string ModelFactory::alternativePlan = "alternativePlan";
  */
 ModelFactory::ModelFactory(PlanParser* p, PlanRepository* rep)
 {
-    this->_parser = p;
-    this->_rep = rep;
-    this->ignoreMasterPlanId = false;
+    _parser = p;
+    _rep = rep;
+    ignoreMasterPlanId = false;
 }
 
 ModelFactory::~ModelFactory()
 {
-    for (auto iter : this->_elements) {
+    for (auto iter : _elements) {
         delete iter.second;
     }
 }
 
 void ModelFactory::setIgnoreMasterPlanId(bool value)
 {
-    this->ignoreMasterPlanId = value;
+    ignoreMasterPlanId = value;
 }
 
 bool ModelFactory::getIgnoreMasterPlanId()
 {
-    return this->ignoreMasterPlanId;
+    return ignoreMasterPlanId;
 }
 
 Plan* ModelFactory::createPlan(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
 
-    int64_t id = this->_parser->parserId(element);
+    int64_t id = _parser->parserId(element);
     Plan* plan = new Plan(id);
-    plan->setFileName(this->_parser->getCurrentFile());
+    plan->setFileName(_parser->getCurrentFile());
     setAlicaElementAttributes(plan, element);
 
     string isMasterPlanAttr = element->Attribute("masterPlan");
@@ -148,7 +148,7 @@ Plan* ModelFactory::createPlan(tinyxml2::XMLDocument* node)
     // insert into elements ma
     addElement(plan);
     // insert into plan repository map
-    this->_rep->_plans.emplace(plan->getId(), plan);
+    _rep->_plans.emplace(plan->getId(), plan);
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
 
@@ -274,7 +274,7 @@ RoleSet* ModelFactory::createRoleSet(tinyxml2::XMLDocument* node, Plan* masterPl
     }
 
     RoleSet* rs = new RoleSet();
-    rs->setId(this->_parser->parserId(element));
+    rs->setId(_parser->parserId(element));
     setAlicaElementAttributes(rs, element);
     rs->setIsDefault(isDefault);
     rs->setUsableWithPlanId(pid);
@@ -297,7 +297,7 @@ RoleSet* ModelFactory::createRoleSet(tinyxml2::XMLDocument* node, Plan* masterPl
 RoleTaskMapping* ModelFactory::createRoleTaskMapping(tinyxml2::XMLElement* element)
 {
     RoleTaskMapping* rtm = new RoleTaskMapping();
-    rtm->setId(this->_parser->parserId(element));
+    rtm->setId(_parser->parserId(element));
     setAlicaElementAttributes(rtm, element);
     addElement(rtm);
 
@@ -312,8 +312,8 @@ RoleTaskMapping* ModelFactory::createRoleTaskMapping(tinyxml2::XMLElement* eleme
                 rtm->_taskPriorities.insert(pair<int64_t, double>(stoll(keyPtr), stod(valuePtr)));
             }
         } else if (role.compare(val) == 0) {
-            int64_t cid = this->_parser->parserId(curChild);
-            this->_rtmRoleReferences.push_back(pair<int64_t, int64_t>(rtm->getId(), cid));
+            int64_t cid = _parser->parserId(curChild);
+            _rtmRoleReferences.push_back(pair<int64_t, int64_t>(rtm->getId(), cid));
         } else {
             AlicaEngine::abort("MF: Unhandled RoleTaskMapping Child ", curChild->Value());
         }
@@ -326,7 +326,7 @@ void ModelFactory::createCapabilityDefinitionSet(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
     CapabilityDefinitionSet* capSet = new CapabilityDefinitionSet();
-    capSet->setId(this->_parser->parserId(element));
+    capSet->setId(_parser->parserId(element));
     setAlicaElementAttributes(capSet, element);
     addElement(capSet);
 
@@ -345,17 +345,17 @@ void ModelFactory::createCapabilityDefinitionSet(tinyxml2::XMLDocument* node)
 Capability* ModelFactory::createCapability(tinyxml2::XMLElement* element)
 {
     Capability* cap = new Capability();
-    cap->setId(this->_parser->parserId(element));
+    cap->setId(_parser->parserId(element));
     setAlicaElementAttributes(cap, element);
     addElement(cap);
-    this->_rep->_capabilities.insert(pair<int64_t, Capability*>(cap->getId(), cap));
+    _rep->_capabilities.insert(pair<int64_t, Capability*>(cap->getId(), cap));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
         if (capValues.compare(val) == 0) {
             CapValue* cval = new CapValue();
-            cval->setId(this->_parser->parserId(curChild));
+            cval->setId(_parser->parserId(curChild));
             setAlicaElementAttributes(cval, curChild);
             addElement(cval);
             cap->_capValues.push_back(cval);
@@ -370,11 +370,11 @@ void ModelFactory::createRoleDefinitionSet(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
     RoleDefinitionSet* r = new RoleDefinitionSet();
-    r->setId(this->_parser->parserId(element));
-    r->setFileName(this->_parser->getCurrentFile());
+    r->setId(_parser->parserId(element));
+    r->setFileName(_parser->getCurrentFile());
     setAlicaElementAttributes(r, element);
     addElement(r);
-    this->_rep->_roleDefinitionSets.insert(pair<int64_t, RoleDefinitionSet*>(r->getId(), r));
+    _rep->_roleDefinitionSets.insert(pair<int64_t, RoleDefinitionSet*>(r->getId(), r));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
@@ -393,10 +393,10 @@ void ModelFactory::createRoleDefinitionSet(tinyxml2::XMLDocument* node)
 Role* ModelFactory::createRole(tinyxml2::XMLElement* element)
 {
     Role* r = new Role();
-    r->setId(this->_parser->parserId(element));
+    r->setId(_parser->parserId(element));
     setAlicaElementAttributes(r, element);
     addElement(r);
-    this->_rep->_roles.insert(pair<int64_t, Role*>(r->getId(), r));
+    _rep->_roles.insert(pair<int64_t, Role*>(r->getId(), r));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
@@ -414,7 +414,7 @@ Role* ModelFactory::createRole(tinyxml2::XMLElement* element)
 Characteristic* ModelFactory::createCharacteristic(tinyxml2::XMLElement* element)
 {
     Characteristic* cha = new Characteristic();
-    cha->setId(this->_parser->parserId(element));
+    cha->setId(_parser->parserId(element));
     setAlicaElementAttributes(cha, element);
     const char* attr = element->Attribute("weight");
     if (attr) {
@@ -422,17 +422,17 @@ Characteristic* ModelFactory::createCharacteristic(tinyxml2::XMLElement* element
     }
 
     addElement(cha);
-    this->_rep->_characteristics.insert(pair<int64_t, Characteristic*>(cha->getId(), cha));
+    _rep->_characteristics.insert(pair<int64_t, Characteristic*>(cha->getId(), cha));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
         if (capability.compare(val) == 0) {
-            int64_t capid = this->_parser->parserId(curChild);
-            this->_charCapReferences.push_back(pair<int64_t, int64_t>(cha->getId(), capid));
+            int64_t capid = _parser->parserId(curChild);
+            _charCapReferences.push_back(pair<int64_t, int64_t>(cha->getId(), capid));
         } else if (value.compare(val) == 0) {
-            int64_t capValid = this->_parser->parserId(curChild);
-            this->_charCapValReferences.push_back(pair<int64_t, int64_t>(cha->getId(), capValid));
+            int64_t capValid = _parser->parserId(curChild);
+            _charCapValReferences.push_back(pair<int64_t, int64_t>(cha->getId(), capValid));
         } else {
             AlicaEngine::abort("MF: Unhandled Characteristic Child:", curChild->Value());
         }
@@ -443,20 +443,20 @@ Characteristic* ModelFactory::createCharacteristic(tinyxml2::XMLElement* element
 void ModelFactory::createBehaviour(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
-    int64_t id = this->_parser->parserId(element);
+    int64_t id = _parser->parserId(element);
     Behaviour* beh = new Behaviour();
     beh->setId(id);
 
     setAlicaElementAttributes(beh, element);
     addElement(beh);
-    this->_rep->_behaviours.insert(pair<int64_t, Behaviour*>(beh->getId(), beh));
+    _rep->_behaviours.insert(pair<int64_t, Behaviour*>(beh->getId(), beh));
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        this->_parser->parserId(curChild);
+        _parser->parserId(curChild);
         if (configurations.compare(val) == 0) {
             BehaviourConfiguration* bc = createBehaviourConfiguration(curChild);
-            this->_rep->_behaviourConfigurations.insert(pair<int64_t, BehaviourConfiguration*>(bc->getId(), bc));
+            _rep->_behaviourConfigurations.insert(pair<int64_t, BehaviourConfiguration*>(bc->getId(), bc));
             bc->setBehaviour(beh);
             beh->_configurations.push_back(bc);
         } else {
@@ -468,8 +468,8 @@ void ModelFactory::createBehaviour(tinyxml2::XMLDocument* node)
 BehaviourConfiguration* ModelFactory::createBehaviourConfiguration(tinyxml2::XMLElement* element)
 {
     BehaviourConfiguration* b = new BehaviourConfiguration();
-    b->setId(this->_parser->parserId(element));
-    b->setFileName(this->_parser->getCurrentFile());
+    b->setId(_parser->parserId(element));
+    b->setFileName(_parser->getCurrentFile());
 
     const char* attr = element->Attribute("masterPlan");
     string attrString = "";
@@ -514,11 +514,11 @@ BehaviourConfiguration* ModelFactory::createBehaviourConfiguration(tinyxml2::XML
         b->setFrequency(stoi(attr));
     }
     setAlicaElementAttributes(b, element);
-    this->_elements.insert(pair<int64_t, AlicaElement*>(b->getId(), b));
+    _elements.insert(pair<int64_t, AlicaElement*>(b->getId(), b));
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        this->_parser->parserId(curChild);
+        _parser->parserId(curChild);
         if (vars.compare(val) == 0) {
             Variable* v = createVariable(curChild);
             b->_variables.push_back(v);
@@ -540,11 +540,11 @@ void ModelFactory::createPlanType(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
     PlanType* pt = new PlanType();
-    pt->setId(this->_parser->parserId(element));
-    pt->setFileName(this->_parser->getCurrentFile());
+    pt->setId(_parser->parserId(element));
+    pt->setFileName(_parser->getCurrentFile());
     setAlicaElementAttributes(pt, element);
     addElement(pt);
-    this->_rep->_planTypes.insert(pair<int64_t, PlanType*>(pt->getId(), pt));
+    _rep->_planTypes.insert(pair<int64_t, PlanType*>(pt->getId(), pt));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
@@ -556,8 +556,8 @@ void ModelFactory::createPlanType(tinyxml2::XMLDocument* node)
                 activated = activatedPtr;
                 transform(activated.begin(), activated.end(), activated.begin(), ::tolower);
                 if (activated.compare("true") == 0) {
-                    int64_t cid = this->_parser->parserId(curChild->FirstChildElement());
-                    this->_planTypePlanReferences.push_back(pair<int64_t, int64_t>(pt->getId(), cid));
+                    int64_t cid = _parser->parserId(curChild->FirstChildElement());
+                    _planTypePlanReferences.push_back(pair<int64_t, int64_t>(pt->getId(), cid));
                 }
             } else {
 #ifdef PP_DEBUG
@@ -581,11 +581,11 @@ void ModelFactory::createTasks(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
     TaskRepository* tr = new TaskRepository();
-    tr->setId(this->_parser->parserId(element));
-    tr->setFileName(this->_parser->getCurrentFile());
+    tr->setId(_parser->parserId(element));
+    tr->setFileName(_parser->getCurrentFile());
     addElement(tr);
     setAlicaElementAttributes(tr, element);
-    this->_rep->_taskRepositories.insert(pair<int64_t, TaskRepository*>(tr->getId(), tr));
+    _rep->_taskRepositories.insert(pair<int64_t, TaskRepository*>(tr->getId(), tr));
     int64_t id = 0;
     const char* defaultTaskPtr = element->Attribute("defaultTask");
     if (defaultTaskPtr) {
@@ -595,7 +595,7 @@ void ModelFactory::createTasks(tinyxml2::XMLDocument* node)
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
-        int64_t cid = this->_parser->parserId(curChild);
+        int64_t cid = _parser->parserId(curChild);
 
         Task* task = new Task(cid == id);
         task->setId(cid);
@@ -606,7 +606,7 @@ void ModelFactory::createTasks(tinyxml2::XMLDocument* node)
             task->setDescription(descriptionkPtr);
         }
         addElement(task);
-        this->_rep->_tasks.insert(pair<int64_t, Task*>(task->getId(), task));
+        _rep->_tasks.insert(pair<int64_t, Task*>(task->getId(), task));
         task->setTaskRepository(tr);
         tr->_tasks.push_back(task);
         curChild = curChild->NextSiblingElement();
@@ -616,7 +616,7 @@ void ModelFactory::createTasks(tinyxml2::XMLDocument* node)
 SyncTransition* ModelFactory::createSyncTransition(tinyxml2::XMLElement* element)
 {
     SyncTransition* s = new SyncTransition();
-    s->setId(this->_parser->parserId(element));
+    s->setId(_parser->parserId(element));
     setAlicaElementAttributes(s, element);
     const char* talkTimeoutPtr = element->Attribute("talkTimeout");
     if (talkTimeoutPtr) {
@@ -628,7 +628,7 @@ SyncTransition* ModelFactory::createSyncTransition(tinyxml2::XMLElement* element
     }
 
     addElement(s);
-    this->_rep->_syncTransitions.insert(pair<int64_t, SyncTransition*>(s->getId(), s));
+    _rep->_syncTransitions.insert(pair<int64_t, SyncTransition*>(s->getId(), s));
     if (element->FirstChild()) {
         AlicaEngine::abort("MF: Unhandled Synchtransition Child:", element->FirstChild());
     }
@@ -646,15 +646,15 @@ Variable* ModelFactory::createVariable(tinyxml2::XMLElement* element)
     if (namePtr) {
         name = namePtr;
     }
-    Variable* v = new Variable(this->_parser->parserId(element), name, type);
+    Variable* v = new Variable(_parser->parserId(element), name, type);
     setAlicaElementAttributes(v, element);
     addElement(v);
-    this->_rep->_variables.insert(pair<int64_t, Variable*>(v->getId(), v));
+    _rep->_variables.insert(pair<int64_t, Variable*>(v->getId(), v));
     return v;
 }
 RuntimeCondition* ModelFactory::createRuntimeCondition(tinyxml2::XMLElement* element)
 {
-    RuntimeCondition* r = new RuntimeCondition(this->_parser->parserId(element));
+    RuntimeCondition* r = new RuntimeCondition(_parser->parserId(element));
     setAlicaElementAttributes(r, element);
     addElement(r);
 
@@ -679,9 +679,9 @@ RuntimeCondition* ModelFactory::createRuntimeCondition(tinyxml2::XMLElement* ele
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->_parser->parserId(curChild);
+        int64_t cid = _parser->parserId(curChild);
         if (vars.compare(val) == 0) {
-            this->_conditionVarReferences.push_back(pair<int64_t, int64_t>(r->getId(), cid));
+            _conditionVarReferences.push_back(pair<int64_t, int64_t>(r->getId(), cid));
         } else if (quantifiers.compare(val) == 0) {
             Quantifier* q = createQuantifier(curChild);
             r->_quantifiers.push_back(q);
@@ -700,8 +700,8 @@ void ModelFactory::createPlanningProblem(tinyxml2::XMLDocument* node)
 {
     tinyxml2::XMLElement* element = node->FirstChildElement();
     PlanningProblem* p = new PlanningProblem();
-    p->setId(this->_parser->parserId(element));
-    p->setFileName(this->_parser->getCurrentFile());
+    p->setId(_parser->parserId(element));
+    p->setFileName(_parser->getCurrentFile());
     setAlicaElementAttributes(p, element);
     addElement(p);
 
@@ -747,14 +747,14 @@ void ModelFactory::createPlanningProblem(tinyxml2::XMLDocument* node)
         p->setRequirements("");
     }
 
-    this->_rep->_planningProblems.insert(pair<int64_t, PlanningProblem*>(p->getId(), p));
+    _rep->_planningProblems.insert(pair<int64_t, PlanningProblem*>(p->getId(), p));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->_parser->parserId(curChild);
+        int64_t cid = _parser->parserId(curChild);
         if (plans.compare(val) == 0) {
-            this->_planningProblemPlanReferences.push_back(pair<int64_t, int64_t>(p->getId(), cid));
+            _planningProblemPlanReferences.push_back(pair<int64_t, int64_t>(p->getId(), cid));
         } else if (conditions.compare(val) == 0) {
             const char* type = curChild->Attribute("xsi:type");
             string typeStr;
@@ -774,9 +774,9 @@ void ModelFactory::createPlanningProblem(tinyxml2::XMLDocument* node)
                 AlicaEngine::abort("MF: Unknown Condition type:", curChild->Value());
             }
         } else if (waitPlan.compare(val) == 0) {
-            this->_planningProblemPlanWaitReferences.push_back(pair<int64_t, int64_t>(p->getId(), cid));
+            _planningProblemPlanWaitReferences.push_back(pair<int64_t, int64_t>(p->getId(), cid));
         } else if (alternativePlan.compare(val) == 0) {
-            this->_planningProblemPlanAlternativeReferences.push_back(pair<int64_t, int64_t>(p->getId(), cid));
+            _planningProblemPlanAlternativeReferences.push_back(pair<int64_t, int64_t>(p->getId(), cid));
         }
 
         curChild = curChild->NextSiblingElement();
@@ -786,24 +786,24 @@ void ModelFactory::createPlanningProblem(tinyxml2::XMLDocument* node)
 Transition* ModelFactory::createTransition(tinyxml2::XMLElement* element, Plan* plan)
 {
     Transition* tran = new Transition();
-    tran->setId(this->_parser->parserId(element));
+    tran->setId(_parser->parserId(element));
     setAlicaElementAttributes(tran, element);
     addElement(tran);
-    this->_rep->_transitions.insert(pair<int64_t, Transition*>(tran->getId(), tran));
+    _rep->_transitions.insert(pair<int64_t, Transition*>(tran->getId(), tran));
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->_parser->parserId(curChild);
+        int64_t cid = _parser->parserId(curChild);
         if (inState.compare(val) == 0) {
             // silently ignore
         } else if (outState.compare(val) == 0) {
-            this->_transitionAimReferences.push_back(pair<int64_t, int64_t>(tran->getId(), cid));
+            _transitionAimReferences.push_back(pair<int64_t, int64_t>(tran->getId(), cid));
         } else if (preCondition.compare(val) == 0) {
             PreCondition* pre = createPreCondition(curChild);
             tran->setPreCondition(pre);
             pre->setAbstractPlan(plan);
         } else if (synchronisation.compare(val) == 0) {
-            this->_transitionSynchReferences.push_back(pair<int64_t, int64_t>(tran->getId(), cid));
+            _transitionSynchReferences.push_back(pair<int64_t, int64_t>(tran->getId(), cid));
         } else {
             AlicaEngine::abort("MF: Unhandled Transition Child:", curChild);
         }
@@ -815,7 +815,7 @@ Transition* ModelFactory::createTransition(tinyxml2::XMLElement* element, Plan* 
 PreCondition* ModelFactory::createPreCondition(tinyxml2::XMLElement* element)
 {
     PreCondition* pre = new PreCondition();
-    pre->setId(this->_parser->parserId(element));
+    pre->setId(_parser->parserId(element));
     setAlicaElementAttributes(pre, element);
     addElement(pre);
     string conditionString = "";
@@ -852,9 +852,9 @@ PreCondition* ModelFactory::createPreCondition(tinyxml2::XMLElement* element)
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->_parser->parserId(curChild);
+        int64_t cid = _parser->parserId(curChild);
         if (vars.compare(val) == 0) {
-            this->_conditionVarReferences.push_back(pair<int64_t, int64_t>(pre->getId(), cid));
+            _conditionVarReferences.push_back(pair<int64_t, int64_t>(pre->getId(), cid));
         } else if (quantifiers.compare(val) == 0) {
             Quantifier* q = createQuantifier(curChild);
             pre->_quantifiers.push_back(q);
@@ -872,7 +872,7 @@ PreCondition* ModelFactory::createPreCondition(tinyxml2::XMLElement* element)
 Parameter* ModelFactory::createParameter(tinyxml2::XMLElement* element)
 {
     Parameter* p = new Parameter();
-    int64_t id = this->_parser->parserId(element);
+    int64_t id = _parser->parserId(element);
     p->setId(id);
     addElement(p);
     setAlicaElementAttributes(p, element);
@@ -886,7 +886,7 @@ Parameter* ModelFactory::createParameter(tinyxml2::XMLElement* element)
 Quantifier* ModelFactory::createQuantifier(tinyxml2::XMLElement* element)
 {
     Quantifier* q;
-    int64_t id = this->_parser->parserId(element);
+    int64_t id = _parser->parserId(element);
 
     string typeString = "";
     const char* typePtr = element->Attribute("xsi:type");
@@ -903,14 +903,14 @@ Quantifier* ModelFactory::createQuantifier(tinyxml2::XMLElement* element)
     }
 
     addElement(q);
-    this->_rep->_quantifiers.insert(pair<int64_t, Quantifier*>(q->getId(), q));
+    _rep->_quantifiers.insert(pair<int64_t, Quantifier*>(q->getId(), q));
     setAlicaElementAttributes(q, element);
 
     const char* scopePtr = element->Attribute("scope");
     int64_t cid;
     if (scopePtr) {
         cid = stoll(scopePtr);
-        this->_quantifierScopeReferences.push_back(pair<int64_t, int64_t>(q->getId(), cid));
+        _quantifierScopeReferences.push_back(pair<int64_t, int64_t>(q->getId(), cid));
     }
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
@@ -930,18 +930,18 @@ Quantifier* ModelFactory::createQuantifier(tinyxml2::XMLElement* element)
 FailureState* ModelFactory::createFailureState(tinyxml2::XMLElement* element)
 {
     FailureState* fail = new FailureState();
-    fail->setId(this->_parser->parserId(element));
+    fail->setId(_parser->parserId(element));
     setAlicaElementAttributes(fail, element);
 
     addElement(fail);
-    this->_rep->_states.insert(pair<int64_t, State*>(fail->getId(), fail));
+    _rep->_states.insert(pair<int64_t, State*>(fail->getId(), fail));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->_parser->parserId(curChild);
+        int64_t cid = _parser->parserId(curChild);
         if (inTransitions.compare(val) == 0) {
-            this->_stateInTransitionReferences.push_back(pair<int64_t, int64_t>(fail->getId(), cid));
+            _stateInTransitionReferences.push_back(pair<int64_t, int64_t>(fail->getId(), cid));
         } else if (postCondition.compare(val) == 0) {
             PostCondition* postCon = createPostCondition(curChild);
             fail->setPostCondition(postCon);
@@ -956,18 +956,18 @@ FailureState* ModelFactory::createFailureState(tinyxml2::XMLElement* element)
 SuccessState* ModelFactory::createSuccessState(tinyxml2::XMLElement* element)
 {
     SuccessState* suc = new SuccessState();
-    suc->setId(this->_parser->parserId(element));
+    suc->setId(_parser->parserId(element));
     setAlicaElementAttributes(suc, element);
 
     addElement(suc);
-    this->_rep->_states.insert(pair<int64_t, State*>(suc->getId(), suc));
+    _rep->_states.insert(pair<int64_t, State*>(suc->getId(), suc));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->_parser->parserId(curChild);
+        int64_t cid = _parser->parserId(curChild);
         if (inTransitions.compare(val) == 0) {
-            this->_stateInTransitionReferences.push_back(pair<int64_t, int64_t>(suc->getId(), cid));
+            _stateInTransitionReferences.push_back(pair<int64_t, int64_t>(suc->getId(), cid));
         } else if (postCondition.compare(val) == 0) {
             PostCondition* postCon = createPostCondition(curChild);
             suc->setPostCondition(postCon);
@@ -982,7 +982,7 @@ SuccessState* ModelFactory::createSuccessState(tinyxml2::XMLElement* element)
 PostCondition* ModelFactory::createPostCondition(tinyxml2::XMLElement* element)
 {
     PostCondition* pos = new PostCondition();
-    pos->setId(this->_parser->parserId(element));
+    pos->setId(_parser->parserId(element));
     setAlicaElementAttributes(pos, element);
     addElement(pos);
 
@@ -1014,7 +1014,7 @@ PostCondition* ModelFactory::createPostCondition(tinyxml2::XMLElement* element)
 EntryPoint* ModelFactory::createEntryPoint(tinyxml2::XMLElement* element)
 {
     EntryPoint* ep = new EntryPoint();
-    ep->setId(this->_parser->parserId(element));
+    ep->setId(_parser->parserId(element));
     setAlicaElementAttributes(ep, element);
     string attr = element->Attribute("minCardinality");
     if (!attr.empty()) {
@@ -1031,20 +1031,20 @@ EntryPoint* ModelFactory::createEntryPoint(tinyxml2::XMLElement* element)
     }
 
     addElement(ep);
-    this->_rep->_entryPoints.insert(pair<int64_t, EntryPoint*>(ep->getId(), ep));
+    _rep->_entryPoints.insert(pair<int64_t, EntryPoint*>(ep->getId(), ep));
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     bool haveState = false;
     int64_t curChildId;
 
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        curChildId = this->_parser->parserId(curChild);
+        curChildId = _parser->parserId(curChild);
 
         if (state.compare(val) == 0) {
-            this->_epStateReferences.push_back(pair<int64_t, int64_t>(ep->getId(), curChildId));
+            _epStateReferences.push_back(pair<int64_t, int64_t>(ep->getId(), curChildId));
             haveState = true;
         } else if (task.compare(val) == 0) {
-            this->_epTaskReferences.push_back(pair<int64_t, int64_t>(ep->getId(), curChildId));
+            _epTaskReferences.push_back(pair<int64_t, int64_t>(ep->getId(), curChildId));
         } else {
             AlicaEngine::abort("MF: Unhandled EntryPoint Child: ", val);
         }
@@ -1065,22 +1065,22 @@ EntryPoint* ModelFactory::createEntryPoint(tinyxml2::XMLElement* element)
 State* ModelFactory::createState(tinyxml2::XMLElement* element)
 {
     State* s = new State();
-    s->setId(this->_parser->parserId(element));
+    s->setId(_parser->parserId(element));
     setAlicaElementAttributes(s, element);
 
     addElement(s);
-    this->_rep->_states.insert(pair<int64_t, State*>(s->getId(), s));
+    _rep->_states.insert(pair<int64_t, State*>(s->getId(), s));
 
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->_parser->parserId(curChild);
+        int64_t cid = _parser->parserId(curChild);
         if (inTransitions.compare(val) == 0) {
-            this->_stateInTransitionReferences.push_back(pair<int64_t, int64_t>(s->getId(), cid));
+            _stateInTransitionReferences.push_back(pair<int64_t, int64_t>(s->getId(), cid));
         } else if (outTransitions.compare(val) == 0) {
-            this->_stateOutTransitionReferences.push_back(pair<int64_t, int64_t>(s->getId(), cid));
+            _stateOutTransitionReferences.push_back(pair<int64_t, int64_t>(s->getId(), cid));
         } else if (plans.compare(val) == 0) {
-            this->_statePlanReferences.push_back(pair<int64_t, int64_t>(s->getId(), cid));
+            _statePlanReferences.push_back(pair<int64_t, int64_t>(s->getId(), cid));
         } else if (parametrisation.compare(val) == 0) {
             Parametrisation* para = createParametrisation(curChild);
             s->_parametrisation.push_back(para);
@@ -1096,20 +1096,20 @@ State* ModelFactory::createState(tinyxml2::XMLElement* element)
 Parametrisation* ModelFactory::createParametrisation(tinyxml2::XMLElement* element)
 {
     Parametrisation* para = new Parametrisation();
-    para->setId(this->_parser->parserId(element));
+    para->setId(_parser->parserId(element));
     setAlicaElementAttributes(para, element);
 
     addElement(para);
     tinyxml2::XMLElement* curChild = element->FirstChildElement();
     while (curChild != nullptr) {
         const char* val = curChild->Value();
-        int64_t cid = this->_parser->parserId(curChild);
+        int64_t cid = _parser->parserId(curChild);
         if (subplan.compare(val) == 0) {
-            this->_paramSubPlanReferences.push_back(pair<int64_t, int64_t>(para->getId(), cid));
+            _paramSubPlanReferences.push_back(pair<int64_t, int64_t>(para->getId(), cid));
         } else if (subvar.compare(val) == 0) {
-            this->_paramSubVarReferences.push_back(pair<int64_t, int64_t>(para->getId(), cid));
+            _paramSubVarReferences.push_back(pair<int64_t, int64_t>(para->getId(), cid));
         } else if (var.compare(val) == 0) {
-            this->_paramVarReferences.push_back(pair<int64_t, int64_t>(para->getId(), cid));
+            _paramVarReferences.push_back(pair<int64_t, int64_t>(para->getId(), cid));
         } else {
             AlicaEngine::abort("MF: Unhandled Parametrisation Child:", curChild);
         }
@@ -1186,146 +1186,84 @@ void ModelFactory::computeReachabilities()
     cout << "MF: Computing Reachability sets...done!" << endl;
 #endif
 }
+
+template <class ff, class ss>
+void ModelFactory::iterateAndClear(ReferenceList& l, std::function<void(ff*, ss*)> func)
+{
+    for (pair<int64_t, int64_t>& pairs : l) {
+        ff* f = static_cast<ff*>(_elements.find(pairs.first)->second);
+        ss* s = static_cast<ss*>(_elements.find(pairs.second)->second);
+        func(f, s);
+    }
+    l.clear();
+}
+
 void ModelFactory::attachPlanReferences()
 {
 #ifdef MF_DEBUG
     cout << "MF: Attaching Plan references.." << endl;
 #endif
+
     // epTaskReferences
-    for (pair<int64_t, int64_t> pairs : this->_epTaskReferences) {
-        Task* t = (Task*) this->_elements.find(pairs.second)->second;
-        EntryPoint* ep = (EntryPoint*) this->_elements.find(pairs.first)->second;
-        ep->setTask(t);
-    }
-    this->_epTaskReferences.clear();
+    iterateAndClear<EntryPoint, Task>(_epTaskReferences, [](EntryPoint* e, Task* t) { e->setTask(t); });
 
     // transitionAimReferences
-    for (pair<int64_t, int64_t> pairs : this->_transitionAimReferences) {
-        Transition* t = (Transition*) this->_elements.find(pairs.first)->second;
-        State* st = (State*) this->_elements.find(pairs.second)->second;
-        if (!st) {
-            AlicaEngine::abort("MF: Cannot resolve transitionAimReferences target: ", pairs.first);
-        }
-        t->setOutState(st);
-        st->_inTransitions.push_back(t);
-    }
-    this->_transitionAimReferences.clear();
+    iterateAndClear<Transition, State>(_transitionAimReferences, [](Transition* t, State* s) {
+        t->setOutState(s);
+        s->_inTransitions.push_back(t);
+    });
 
     // epStateReferences
-    for (std::pair<int64_t, int64_t> pairs : this->_epStateReferences) {
-        State* st = (State*) this->_elements.find(pairs.second)->second;
-        EntryPoint* ep = (EntryPoint*) this->_elements.find(pairs.first)->second;
-        ep->setState(st); // back reference will be set later
-    }
-    this->_epStateReferences.clear();
+    iterateAndClear<EntryPoint, State>(_epStateReferences, [](EntryPoint* e, State* s) { e->setState(s); });
 
     // stateInTransitionReferences
-    for (pair<int64_t, int64_t> pairs : this->_stateInTransitionReferences) {
-        Transition* t = (Transition*) this->_elements.find(pairs.second)->second;
-        State* st = (State*) this->_elements.find(pairs.first)->second;
-        if (st != t->getOutState()) {
-            AlicaEngine::abort("MF: Unexpected reference in a transition! ", pairs.first);
+    iterateAndClear<State, Transition>(_stateInTransitionReferences, [](State* s, Transition* t) {
+        if (s != t->getOutState()) {
+            AlicaEngine::abort("MF: Unexpected reference in a transition! ");
         }
-    }
-    this->_stateInTransitionReferences.clear();
+    });
 
     // stateOutTransitionReferences
-    for (pair<int64_t, int64_t> pairs : this->_stateOutTransitionReferences) {
-        State* st = (State*) this->_elements.find(pairs.first)->second;
-        Transition* t = (Transition*) this->_elements.find(pairs.second)->second;
-        st->_outTransitions.push_back(t);
-        t->setInState(st);
-    }
-    this->_stateOutTransitionReferences.clear();
+    iterateAndClear<State, Transition>(_stateOutTransitionReferences, [](State* s, Transition* t) {
+        s->_outTransitions.push_back(t);
+        t->setInState(s);
+    });
 
     // statePlanReferences
-    for (pair<int64_t, int64_t> pairs : this->_statePlanReferences) {
-        State* st = (State*) this->_elements.find(pairs.first)->second;
-        AbstractPlan* p = (AbstractPlan*) this->_elements.find(pairs.second)->second;
-        st->_plans.push_back(p);
-    }
-    this->_statePlanReferences.clear();
+    iterateAndClear<State, AbstractPlan>(_statePlanReferences, [](State* s, AbstractPlan* p) { s->_plans.push_back(p); });
 
     // planTypePlanReferences
-    for (pair<int64_t, int64_t> pairs : this->_planTypePlanReferences) {
-        PlanType* pt = (PlanType*) this->_elements.find(pairs.first)->second;
-        Plan* p = (Plan*) this->_elements.find(pairs.second)->second;
-        pt->_plans.push_back(p);
-    }
-    this->_planTypePlanReferences.clear();
+    iterateAndClear<PlanType, Plan>(_planTypePlanReferences, [](PlanType* pt, Plan* p) { pt->_plans.push_back(p); });
 
     // conditionVarReferences
-    for (pair<int64_t, int64_t> pairs : this->_conditionVarReferences) {
-        Condition* c = (Condition*) this->_elements.find(pairs.first)->second;
-        Variable* v = (Variable*) this->_elements.find(pairs.second)->second;
-        c->_variables.push_back(v);
-    }
-    this->_conditionVarReferences.clear();
+    iterateAndClear<Condition, Variable>(_conditionVarReferences, [](Condition* c, Variable* v) { c->_variables.push_back(v); });
 
     // paramSubPlanReferences
-    for (pair<int64_t, int64_t> pairs : this->_paramSubPlanReferences) {
-        Parametrisation* p = (Parametrisation*) this->_elements.find(pairs.first)->second;
-        AbstractPlan* ap = (AbstractPlan*) this->_elements.find(pairs.second)->second;
-        p->setSubPlan(ap);
-    }
-    this->_paramSubPlanReferences.clear();
+    iterateAndClear<Parametrisation, AbstractPlan>(_paramSubPlanReferences, [](Parametrisation* p, AbstractPlan* ap) { p->setSubPlan(ap); });
 
     // paramSubVarReferences
-    for (pair<int64_t, int64_t> pairs : this->_paramSubVarReferences) {
-        Parametrisation* p = (Parametrisation*) this->_elements.find(pairs.first)->second;
-        Variable* ap = (Variable*) this->_elements.find(pairs.second)->second;
-        p->setSubVar(ap);
-    }
-    this->_paramSubVarReferences.clear();
+    iterateAndClear<Parametrisation, Variable>(_paramSubVarReferences, [](Parametrisation* p, Variable* v) { p->setSubVar(v); });
 
     // paramVarReferences
-    for (pair<int64_t, int64_t> pairs : this->_paramVarReferences) {
-        Parametrisation* p = (Parametrisation*) this->_elements.find(pairs.first)->second;
-        Variable* v = (Variable*) this->_elements.find(pairs.second)->second;
-        p->setVar(v);
-    }
-    this->_paramVarReferences.clear();
+    iterateAndClear<Parametrisation, Variable>(_paramVarReferences, [](Parametrisation* p, Variable* v) { p->setVar(v); });
 
     // transitionSynchReferences
-    for (pair<int64_t, int64_t> pairs : this->_transitionSynchReferences) {
-        Transition* t = (Transition*) this->_elements.find(pairs.first)->second;
-        SyncTransition* sync = (SyncTransition*) this->_elements.find(pairs.second)->second;
-        t->setSyncTransition(sync);
-        sync->_inSync.push_back(t);
-    }
-    this->_transitionSynchReferences.clear();
+    iterateAndClear<Transition, SyncTransition>(_transitionSynchReferences, [](Transition* t, SyncTransition* st) {
+        t->setSyncTransition(st);
+        st->_inSync.push_back(t);
+    });
 
     // planningProblemPlanReferences
-    for (pair<int64_t, int64_t> pairs : this->_planningProblemPlanReferences) {
-        PlanningProblem* s = (PlanningProblem*) this->_elements.find(pairs.first)->second;
-        AbstractPlan* p = (AbstractPlan*) this->_elements.find(pairs.second)->second;
-        s->_plans.push_back(p);
-    }
-    this->_planningProblemPlanReferences.clear();
+    iterateAndClear<PlanningProblem, AbstractPlan>(_planningProblemPlanReferences, [](PlanningProblem* pp, AbstractPlan* ap) { pp->_plans.push_back(ap); });
 
     // planningProblemPlanWaitReferences
-    for (pair<int64_t, int64_t> pairs : this->_planningProblemPlanWaitReferences) {
-        PlanningProblem* s = (PlanningProblem*) this->_elements.find(pairs.first)->second;
-        Plan* p = (Plan*) this->_elements.find(pairs.second)->second;
-        s->setWaitPlan(p);
-    }
-    this->_planningProblemPlanWaitReferences.clear();
+    iterateAndClear<PlanningProblem, Plan>(_planningProblemPlanWaitReferences, [](PlanningProblem* pp, Plan* p) { pp->setWaitPlan(p); });
 
     // planningProblemPlanAlternativeReferences
-    for (pair<int64_t, int64_t> pairs : this->_planningProblemPlanAlternativeReferences) {
-        PlanningProblem* s = (PlanningProblem*) this->_elements.find(pairs.first)->second;
-        Plan* p = (Plan*) this->_elements.find(pairs.second)->second;
-        s->setAlternativePlan(p);
-    }
-    this->_planningProblemPlanAlternativeReferences.clear();
+    iterateAndClear<PlanningProblem, Plan>(_planningProblemPlanAlternativeReferences, [](PlanningProblem* pp, Plan* p) { pp->setAlternativePlan(p); });
 
     // quantifierScopeReferences
-    for (pair<int64_t, int64_t> pairs : this->_quantifierScopeReferences) {
-        AlicaElement* ael = (AlicaElement*) this->_elements.find(pairs.second)->second;
-        Quantifier* q = (Quantifier*) this->_elements.find(pairs.first)->second;
-        q->setScope(ael);
-    }
-    this->_quantifierScopeReferences.clear();
+    iterateAndClear<Quantifier, AlicaElement>(_quantifierScopeReferences, [](Quantifier* q, AlicaElement* ae) { q->setScope(ae); });
 
     createVariableTemplates();
     removeRedundancy();
@@ -1338,13 +1276,13 @@ void ModelFactory::attachRoleReferences()
 #ifdef MF_DEBUG
     cout << "MF: Attaching Role references..." << endl;
 #endif
-    for (pair<int64_t, int64_t> pairs : this->_rtmRoleReferences) {
-        Role* r = this->_rep->_roles.find(pairs.second)->second;
-        RoleTaskMapping* rtm = static_cast<RoleTaskMapping*>(this->_elements.find(pairs.first)->second);
+    for (pair<int64_t, int64_t>& pairs : _rtmRoleReferences) {
+        Role* r = _rep->_roles.find(pairs.second)->second;
+        RoleTaskMapping* rtm = static_cast<RoleTaskMapping*>(_elements.find(pairs.first)->second);
         r->setRoleTaskMapping(rtm);
         rtm->setRole(r);
     }
-    this->_rtmRoleReferences.clear();
+    _rtmRoleReferences.clear();
 #ifdef MF_DEBUG
     cout << "MF: Attaching Role references... done!" << endl;
 #endif
@@ -1354,19 +1292,19 @@ void ModelFactory::attachCharacteristicReferences()
 #ifdef MF_DEBUG
     cout << "MF: Attaching Characteristics references..." << endl;
 #endif
-    for (pair<int64_t, int64_t> pairs : this->_charCapReferences) {
-        Characteristic* cha = this->_rep->_characteristics.find(pairs.first)->second;
-        Capability* cap = static_cast<Capability*>(this->_elements.find(pairs.second)->second);
+    for (pair<int64_t, int64_t>& pairs : _charCapReferences) {
+        Characteristic* cha = _rep->_characteristics.find(pairs.first)->second;
+        Capability* cap = static_cast<Capability*>(_elements.find(pairs.second)->second);
         cha->setCapability(cap);
     }
-    this->_charCapReferences.clear();
+    _charCapReferences.clear();
 
-    for (pair<int64_t, int64_t> pairs : this->_charCapValReferences) {
-        Characteristic* cha = this->_rep->_characteristics.find(pairs.first)->second;
-        CapValue* capVal = static_cast<CapValue*>(this->_elements.find(pairs.second)->second);
+    for (pair<int64_t, int64_t>& pairs : _charCapValReferences) {
+        Characteristic* cha = _rep->_characteristics.find(pairs.first)->second;
+        CapValue* capVal = static_cast<CapValue*>(_elements.find(pairs.second)->second);
         cha->setCapValue(capVal);
     }
-    this->_charCapValReferences.clear();
+    _charCapValReferences.clear();
 #ifdef MF_DEBUG
     cout << "MF: Attaching Characteristics references... done!" << endl;
 #endif
@@ -1374,7 +1312,7 @@ void ModelFactory::attachCharacteristicReferences()
 
 void ModelFactory::createVariableTemplates()
 {
-    for (std::pair<const int64_t, Quantifier*> p : _rep->_quantifiers) {
+    for (std::pair<const int64_t, Quantifier*>& p : _rep->_quantifiers) {
         Quantifier* q = p.second;
         for (const std::string& s : q->getDomainIdentifiers()) {
             int64_t id = Hash64(s.c_str(), s.size());
@@ -1404,20 +1342,20 @@ void ModelFactory::removeRedundancy()
     }
 }
 
-map<int64_t, AlicaElement*>* ModelFactory::getElements()
+bool ModelFactory::isUniqueElement(int64_t elementId)
 {
-    return &this->_elements;
+    return _elements.find(elementId) == _elements.end();
 }
 
 void ModelFactory::setElements(const map<int64_t, AlicaElement*>& elements)
 {
-    this->_elements = elements;
+    _elements = elements;
 }
 
 void ModelFactory::addElement(AlicaElement* ael)
 {
-    if (this->_elements.find(ael->getId()) != this->_elements.end()) {
-        cout << "ELEMENT >" << ael->getName() << "< >" << this->_elements[ael->getId()]->getName() << "<" << endl;
+    if (_elements.find(ael->getId()) != _elements.end()) {
+        cout << "ELEMENT >" << ael->getName() << "< >" << _elements[ael->getId()]->getName() << "<" << endl;
         stringstream ss;
         ss << "MF: ERROR Double IDs: " << ael->getId();
         cout << segfaultdebug::get_stacktrace() << endl;

--- a/alica_engine/src/engine/parser/PlanParser.cpp
+++ b/alica_engine/src/engine/parser/PlanParser.cpp
@@ -104,9 +104,9 @@ const RoleSet* PlanParser::parseRoleSet(std::string roleSetName)
 
     _filesParsed.push_back(roleSetLocation);
 
-    while (!_filesToParse.empty()) {
-        const std::string fileToParse = _filesToParse.front();
-        _filesToParse.pop_front();
+    // This vector will grow while parsing and will be cleared at end of loop
+    for (size_t count = 0; count < _filesToParse.size(); ++count) {
+        const std::string fileToParse = _filesToParse[count];
         _currentDirectory = essentials::FileSystem::getParent(fileToParse);
         _currentFile = fileToParse;
 
@@ -122,6 +122,7 @@ const RoleSet* PlanParser::parseRoleSet(std::string roleSetName)
         }
         _filesParsed.push_back(fileToParse);
     }
+    _filesToParse.clear();
 
     _mf.attachRoleReferences();
     _mf.attachCharacteristicReferences();
@@ -212,9 +213,9 @@ const Plan* PlanParser::parsePlanTree(const std::string& masterplan)
 
 void PlanParser::parseFileLoop()
 {
-    while (!_filesToParse.empty()) {
-        const std::string fileToParse = _filesToParse.front();
-        _filesToParse.pop_front();
+    // This vector will grow while parsing and will be cleared at end of loop
+    for (size_t count = 0; count < _filesToParse.size(); ++count) {
+        const std::string fileToParse = _filesToParse[count];
         _currentDirectory = essentials::FileSystem::getParent(fileToParse);
         _currentFile = fileToParse;
 
@@ -236,6 +237,7 @@ void PlanParser::parseFileLoop()
         }
         _filesParsed.push_back(fileToParse);
     }
+    _filesToParse.clear();
     _mf.attachPlanReferences();
 }
 
@@ -403,7 +405,6 @@ int64_t PlanParser::fetchId(const string& idString, int64_t id)
             }
         }
 
-        // list<string>::iterator findIterToParse = find(_filesToParse.begin(), _filesToParse.end(), pathNew);
         if (!found) {
             for (const auto& it : _filesToParse) {
                 temp2 = realpath(it.c_str(), nullptr);

--- a/alica_engine/src/engine/parser/PlanWriter.cpp
+++ b/alica_engine/src/engine/parser/PlanWriter.cpp
@@ -46,14 +46,14 @@ using std::string;
 using std::stringstream;
 using std::to_string;
 
-int PlanWriter::objectCounter = 0;
+int PlanWriter::s_objectCounter = 0;
 
 PlanWriter::PlanWriter(AlicaEngine* ae, PlanRepository* rep)
 {
     this->ae = ae;
     string path = essentials::SystemConfig::getInstance().getConfigPath();
     this->tempPlanDir = essentials::FileSystem::combinePaths(path, "plans/tmp/");
-    this->rep = rep;
+    this->_rep = rep;
 }
 
 PlanWriter::~PlanWriter() {}
@@ -88,7 +88,7 @@ void PlanWriter::setPlansToSave(const AlicaElementGrp& plansToSave)
 void PlanWriter::saveAllPlans()
 {
     this->plansToSave.clear();
-    for (const Plan* p : this->rep->getPlans()) {
+    for (const Plan* p : this->_rep->getPlans()) {
         this->plansToSave.push_back(p);
     }
     saveFileLoop();
@@ -100,24 +100,24 @@ void PlanWriter::saveAllPlans()
  */
 void PlanWriter::saveSinglePlan(const Plan* p)
 {
-    this->currentFile = essentials::FileSystem::combinePaths(this->tempPlanDir, p->getName() + string(".pml"));
+    this->_currentFile = essentials::FileSystem::combinePaths(this->tempPlanDir, p->getName() + string(".pml"));
     tinyxml2::XMLDocument* doc = createPlanXMLDocument(p);
 
     if (!essentials::FileSystem::pathExists(this->tempPlanDir)) {
         essentials::FileSystem::createDirectory(this->tempPlanDir, 777);
     }
-    doc->SaveFile(this->currentFile.c_str(), false);
+    doc->SaveFile(this->_currentFile.c_str(), false);
 }
 
 void PlanWriter::saveSinglePlan(std::string directory, const Plan* p)
 {
-    this->currentFile = essentials::FileSystem::combinePaths(directory, p->getFileName());
+    this->_currentFile = essentials::FileSystem::combinePaths(directory, p->getFileName());
     tinyxml2::XMLDocument* doc = createPlanXMLDocument(p);
 
     if (!essentials::FileSystem::pathExists(directory)) {
         essentials::FileSystem::createDirectory(directory, 777);
     }
-    doc->SaveFile(this->currentFile.c_str(), false);
+    doc->SaveFile(this->_currentFile.c_str(), false);
 }
 
 void PlanWriter::saveFileLoop()
@@ -248,24 +248,24 @@ tinyxml2::XMLDocument* PlanWriter::createRoleSetXMLDocument(const RoleSet* r)
 
 void PlanWriter::saveRoleSet(const RoleSet* r, string name)
 {
-    this->currentFile = essentials::FileSystem::combinePaths(this->tempPlanDir, name);
+    this->_currentFile = essentials::FileSystem::combinePaths(this->tempPlanDir, name);
     tinyxml2::XMLDocument* doc = createRoleSetXMLDocument(r);
 
     if (!essentials::FileSystem::pathExists(this->tempPlanDir)) {
         essentials::FileSystem::createDirectory(this->tempPlanDir, 777);
     }
-    doc->SaveFile(this->currentFile.c_str(), false);
+    doc->SaveFile(this->_currentFile.c_str(), false);
 }
 
 void PlanWriter::saveRoleSet(const RoleSet* r, string directory, string name)
 {
-    this->currentFile = essentials::FileSystem::combinePaths(directory, name);
+    this->_currentFile = essentials::FileSystem::combinePaths(directory, name);
     tinyxml2::XMLDocument* doc = createRoleSetXMLDocument(r);
 
     if (!essentials::FileSystem::pathExists(directory)) {
         essentials::FileSystem::createDirectory(directory, 777);
     }
-    doc->SaveFile(this->currentFile.c_str(), false);
+    doc->SaveFile(this->_currentFile.c_str(), false);
 }
 
 tinyxml2::XMLDocument* PlanWriter::createTaskRepositoryXMLDocument(const TaskRepository* tr)
@@ -282,24 +282,24 @@ tinyxml2::XMLDocument* PlanWriter::createTaskRepositoryXMLDocument(const TaskRep
 
 void PlanWriter::saveTaskRepository(const TaskRepository* tr, string name)
 {
-    this->currentFile = essentials::FileSystem::combinePaths(this->tempPlanDir, name);
+    this->_currentFile = essentials::FileSystem::combinePaths(this->tempPlanDir, name);
     tinyxml2::XMLDocument* doc = createTaskRepositoryXMLDocument(tr);
 
     if (!essentials::FileSystem::pathExists(this->tempPlanDir)) {
         essentials::FileSystem::createDirectory(this->tempPlanDir, 777);
     }
-    doc->SaveFile(this->currentFile.c_str(), false);
+    doc->SaveFile(this->_currentFile.c_str(), false);
 }
 
 void PlanWriter::saveTaskRepository(const TaskRepository* tr, string directory, string name)
 {
-    this->currentFile = essentials::FileSystem::combinePaths(directory, name);
+    this->_currentFile = essentials::FileSystem::combinePaths(directory, name);
     tinyxml2::XMLDocument* doc = createTaskRepositoryXMLDocument(tr);
 
     if (!essentials::FileSystem::pathExists(directory)) {
         essentials::FileSystem::createDirectory(directory, 777);
     }
-    doc->SaveFile(this->currentFile.c_str(), false);
+    doc->SaveFile(this->_currentFile.c_str(), false);
 }
 
 void PlanWriter::addConditionChildren(const Condition* c, tinyxml2::XMLElement* xn, tinyxml2::XMLDocument* doc)
@@ -515,7 +515,7 @@ tinyxml2::XMLElement* PlanWriter::createEntryPointXMLNode(const EntryPoint* e, t
     xe->SetAttribute("minCardinality", e->getMinCardinality());
     xe->SetAttribute("maxCardinality", e->getMaxCardinality());
     tinyxml2::XMLElement* xc = doc->NewElement("task");
-    xc->InsertEndChild(doc->NewText((getRelativeFileName(this->rep->getTaskRepositorys()[e->getTask()->getTaskRepository()->getId()]->getFileName()) + "#" +
+    xc->InsertEndChild(doc->NewText((getRelativeFileName(this->_rep->getTaskRepositorys()[e->getTask()->getTaskRepository()->getId()]->getFileName()) + "#" +
                                      to_string(e->getTask()->getId()))
                                             .c_str()));
     xe->InsertEndChild(xc);
@@ -534,7 +534,7 @@ void PlanWriter::addPlanElementAttributes(const AlicaElement* p, tinyxml2::XMLEl
 
 std::string PlanWriter::getRelativeFileName(const std::string& file)
 {
-    std::string curdir = this->currentFile;
+    std::string curdir = this->_currentFile;
     std::string ufile = "";
     if (essentials::FileSystem::isPathRooted(file)) {
         ufile = file;
@@ -558,7 +558,7 @@ std::string PlanWriter::getRelativeFileName(const std::string& file)
             }
             ufile = tfile;
         } else {
-            cout << "File reference not implemented: " << file << "(occurred in file " << this->currentFile << ")" << endl;
+            cout << "File reference not implemented: " << file << "(occurred in file " << this->_currentFile << ")" << endl;
             throw std::exception();
         }
     }
@@ -593,7 +593,7 @@ void PlanWriter::createRoleSet(const RoleSet* r, tinyxml2::XMLDocument* doc)
     xp->SetAttribute("xmi:version", "2.0");
     xp->SetAttribute("xmlns:xmi", "http://www.omg.org/XMI");
     xp->SetAttribute("xmlns:alica", "http:///de.uni_kassel.vs.cn");
-    xp->SetAttribute("id", to_string(ae->getAlicaClock()->now().inNanoseconds() + objectCounter++).c_str());
+    xp->SetAttribute("id", to_string(ae->getAlicaClock()->now().inNanoseconds() + s_objectCounter++).c_str());
     xp->SetAttribute("name", r->getName().c_str());
     xp->SetAttribute("usableWithPlanID", to_string(r->getUsableWithPlanId()).c_str());
     if (r->isDefault()) {
@@ -605,12 +605,12 @@ void PlanWriter::createRoleSet(const RoleSet* r, tinyxml2::XMLDocument* doc)
     for (const RoleTaskMapping* rtm : r->getRoleTaskMappings()) {
         tinyxml2::XMLElement* xc = doc->NewElement("mappings");
         xp->InsertEndChild(xc);
-        xc->SetAttribute("id", to_string(ae->getAlicaClock()->now().inNanoseconds() + objectCounter++).c_str());
+        xc->SetAttribute("id", to_string(ae->getAlicaClock()->now().inNanoseconds() + s_objectCounter++).c_str());
         xc->SetAttribute("name", rtm->getName().c_str());
         for (auto mapping : rtm->getTaskPriorities()) {
             tinyxml2::XMLElement* xd = doc->NewElement("taskPriorities");
             xc->InsertEndChild(xd);
-            xd->SetAttribute("id", to_string(ae->getAlicaClock()->now().inNanoseconds() + objectCounter++).c_str());
+            xd->SetAttribute("id", to_string(ae->getAlicaClock()->now().inNanoseconds() + s_objectCounter++).c_str());
             xd->SetAttribute("name", "");
             xd->SetAttribute("key", to_string(mapping.first).c_str());
             xd->SetAttribute("value", to_string(mapping.second).c_str());
@@ -628,7 +628,7 @@ void PlanWriter::createTaskRepository(const TaskRepository* tr, tinyxml2::XMLDoc
     xp->SetAttribute("xmi:version", "2.0");
     xp->SetAttribute("xmlns:xmi", "http://www.omg.org/XMI");
     xp->SetAttribute("xmlns:alica", "http:///de.uni_kassel.vs.cn");
-    xp->SetAttribute("id", to_string(ae->getAlicaClock()->now().inNanoseconds() + objectCounter++).c_str());
+    xp->SetAttribute("id", to_string(ae->getAlicaClock()->now().inNanoseconds() + s_objectCounter++).c_str());
     xp->SetAttribute("name", tr->getName().c_str());
     xp->SetAttribute("defaultTask", to_string(tr->getDefaultTask()).c_str());
 

--- a/alica_engine/src/engine/teammanager/TeamManager.cpp
+++ b/alica_engine/src/engine/teammanager/TeamManager.cpp
@@ -41,12 +41,11 @@ void TeamManager::readTeamFromConfig()
     std::string localAgentName = _engine->getRobotName();
     std::shared_ptr<std::vector<std::string>> agentNames = sc["Globals"]->getSections("Globals.Team", NULL);
 
-    Agent* agent;
     bool foundSelf = false;
     for (const std::string& agentName : *agentNames) {
         int id = sc["Globals"]->tryGet<int>(-1, "Globals", "Team", agentName.c_str(), "ID", NULL);
 
-        agent = new Agent(_engine, _teamTimeOut, _engine->getId(id), agentName);
+        Agent* agent = new Agent(_engine, _teamTimeOut, _engine->getId(id), agentName);
         if (!foundSelf && agentName.compare(localAgentName) == 0) {
             foundSelf = true;
             _localAgent = agent;

--- a/alica_engine/src/engine/teammanager/TeamManager.cpp
+++ b/alica_engine/src/engine/teammanager/TeamManager.cpp
@@ -12,9 +12,9 @@ namespace alica
 {
 
 TeamManager::TeamManager(AlicaEngine* engine, bool useConfigForTeam = true)
-        : localAgent(nullptr)
-        , useConfigForTeam(useConfigForTeam)
-        , engine(engine)
+        : _localAgent(nullptr)
+        , _useConfigForTeam(useConfigForTeam)
+        , _engine(engine)
 {
 }
 
@@ -28,9 +28,9 @@ TeamManager::~TeamManager()
 void TeamManager::init()
 {
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
-    this->teamTimeOut = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica.TeamTimeOut", NULL));
+    this->_teamTimeOut = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica.TeamTimeOut", NULL));
 
-    if (useConfigForTeam) {
+    if (_useConfigForTeam) {
         this->readTeamFromConfig();
     }
 }
@@ -38,7 +38,7 @@ void TeamManager::init()
 void TeamManager::readTeamFromConfig()
 {
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
-    std::string localAgentName = this->engine->getRobotName();
+    std::string localAgentName = this->_engine->getRobotName();
     std::shared_ptr<std::vector<std::string>> agentNames = sc["Globals"]->getSections("Globals.Team", NULL);
 
     Agent* agent;
@@ -46,11 +46,11 @@ void TeamManager::readTeamFromConfig()
     for (const std::string& agentName : *agentNames) {
         int id = sc["Globals"]->tryGet<int>(-1, "Globals", "Team", agentName.c_str(), "ID", NULL);
 
-        agent = new Agent(this->engine, this->teamTimeOut, this->engine->getId(id), agentName);
+        agent = new Agent(this->_engine, this->_teamTimeOut, this->_engine->getId(id), agentName);
         if (!foundSelf && agentName.compare(localAgentName) == 0) {
             foundSelf = true;
-            this->localAgent = agent;
-            this->localAgent->setLocal(true);
+            this->_localAgent = agent;
+            this->_localAgent->setLocal(true);
         } else {
             for (auto& agentEntry : _agents) {
                 if (*(agentEntry.first) == *(agent->getId())) {
@@ -104,7 +104,7 @@ const Agent* TeamManager::getAgentByID(AgentIDConstPtr agentId) const
 
 AgentIDConstPtr TeamManager::getLocalAgentID() const
 {
-    return this->localAgent->getId();
+    return this->_localAgent->getId();
 }
 
 void TeamManager::setTimeLastMsgReceived(AgentIDConstPtr agentId, AlicaTime timeLastMsgReceived)
@@ -114,7 +114,7 @@ void TeamManager::setTimeLastMsgReceived(AgentIDConstPtr agentId, AlicaTime time
         mapIter->second->setTimeLastMsgReceived(timeLastMsgReceived);
     } else {
         // TODO alex robot properties protokoll anstoßen
-        Agent* agent = new Agent(this->engine, this->teamTimeOut, agentId);
+        Agent* agent = new Agent(this->_engine, this->_teamTimeOut, agentId);
         agent->setTimeLastMsgReceived(timeLastMsgReceived);
         _agents.emplace(agentId, agent);
     }

--- a/alica_engine/src/engine/teammanager/TeamManager.cpp
+++ b/alica_engine/src/engine/teammanager/TeamManager.cpp
@@ -28,17 +28,17 @@ TeamManager::~TeamManager()
 void TeamManager::init()
 {
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
-    this->_teamTimeOut = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica.TeamTimeOut", NULL));
+    _teamTimeOut = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica.TeamTimeOut", NULL));
 
     if (_useConfigForTeam) {
-        this->readTeamFromConfig();
+        readTeamFromConfig();
     }
 }
 
 void TeamManager::readTeamFromConfig()
 {
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
-    std::string localAgentName = this->_engine->getRobotName();
+    std::string localAgentName = _engine->getRobotName();
     std::shared_ptr<std::vector<std::string>> agentNames = sc["Globals"]->getSections("Globals.Team", NULL);
 
     Agent* agent;
@@ -46,11 +46,11 @@ void TeamManager::readTeamFromConfig()
     for (const std::string& agentName : *agentNames) {
         int id = sc["Globals"]->tryGet<int>(-1, "Globals", "Team", agentName.c_str(), "ID", NULL);
 
-        agent = new Agent(this->_engine, this->_teamTimeOut, this->_engine->getId(id), agentName);
+        agent = new Agent(_engine, _teamTimeOut, _engine->getId(id), agentName);
         if (!foundSelf && agentName.compare(localAgentName) == 0) {
             foundSelf = true;
-            this->_localAgent = agent;
-            this->_localAgent->setLocal(true);
+            _localAgent = agent;
+            _localAgent->setLocal(true);
         } else {
             for (auto& agentEntry : _agents) {
                 if (*(agentEntry.first) == *(agent->getId())) {
@@ -104,7 +104,7 @@ const Agent* TeamManager::getAgentByID(AgentIDConstPtr agentId) const
 
 AgentIDConstPtr TeamManager::getLocalAgentID() const
 {
-    return this->_localAgent->getId();
+    return _localAgent->getId();
 }
 
 void TeamManager::setTimeLastMsgReceived(AgentIDConstPtr agentId, AlicaTime timeLastMsgReceived)
@@ -114,7 +114,7 @@ void TeamManager::setTimeLastMsgReceived(AgentIDConstPtr agentId, AlicaTime time
         mapIter->second->setTimeLastMsgReceived(timeLastMsgReceived);
     } else {
         // TODO alex robot properties protokoll anstoßen
-        Agent* agent = new Agent(this->_engine, this->_teamTimeOut, agentId);
+        Agent* agent = new Agent(_engine, _teamTimeOut, agentId);
         agent->setTimeLastMsgReceived(timeLastMsgReceived);
         _agents.emplace(agentId, agent);
     }


### PR DESCRIPTION
> Forced private variable naming convention in the engine.
> Removed "this->" menace from multiple places.
> Optimized PlanParser and ModelFactory.
