### PR TITLE
Fix for crash if agent is removed from the team while participating in a state under protection timer.

### DIFF
--- a/alica_engine/src/engine/RunningPlan.cpp
+++ b/alica_engine/src/engine/RunningPlan.cpp
@@ -653,10 +653,6 @@ bool RunningPlan::recursiveUpdateAssignment(const std::vector<const SimplePlanTr
             rem.clear();
             AssignmentView robs = _assignment.getAgentsWorking(i);
             for (AgentIDConstPtr rob : robs) {
-                const bool freezeAgent = keepState && _assignment.getStateOfAgent(rob) == getActiveState();
-                if (freezeAgent) {
-                    continue;
-                }
                 if (std::find(availableAgents.begin(), availableAgents.end(), rob) == availableAgents.end()) {
                     rem.push_back(rob);
                     aldif.editSubtractions().emplace_back(ep, rob);


### PR DESCRIPTION
This is the hotfix. Proper fix to rr-devel will include test.