### PR TITLE
Do not prevent an agent from being removed due to state protection timer

### DIFF
--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -80,8 +80,8 @@ public:
     const TeamObserver& getTeamObserver() const { return _teamObserver; }
     TeamObserver& editTeamObserver() { return _teamObserver; }
 
-    const AlicaClock& getAlicaClock() const { return _alicaClock; }
-    // AlicaClock& editAlicaClock() { return _alicaClock; }
+    const AlicaClock& getAlicaClock() const { return *_alicaClock.get(); }
+    void setAlicaClock(std::unique_ptr<AlicaClock> c) { _alicaClock = std::move(c); }
 
     const BlackBoard& getBlackBoard() const { return _blackboard; }
     BlackBoard& editBlackBoard() { return _blackboard; }
@@ -120,7 +120,7 @@ private:
     BehaviourPool _behaviourPool;
     TeamObserver _teamObserver;
     SyncModule _syncModul;
-    AlicaClock _alicaClock;
+    std::unique_ptr<AlicaClock> _alicaClock;
     ExpressionHandler _expressionHandler;
     AuthorityManager _auth;
     Logger _log;

--- a/alica_engine/include/engine/RunningPlan.h
+++ b/alica_engine/include/engine/RunningPlan.h
@@ -101,6 +101,7 @@ public:
     RunningPlan(AlicaEngine* ae, const BehaviourConfiguration* bc);
 
     static void init();
+    static void setAssignmentProtectionTime(AlicaTime t);
 
     virtual ~RunningPlan();
 

--- a/alica_engine/include/engine/teammanager/Agent.h
+++ b/alica_engine/include/engine/teammanager/Agent.h
@@ -35,6 +35,7 @@ public:
     RobotEngineData& editEngineData() { return _engineData; }
     bool isActive() const { return _active; }
     bool isIgnored() const { return _ignored; }
+    void setTimeout(AlicaTime t);
 
 private:
     Agent(const AlicaEngine* engine, AlicaTime timeout, AgentIDConstPtr id);

--- a/alica_engine/include/engine/teammanager/TeamManager.h
+++ b/alica_engine/include/engine/teammanager/TeamManager.h
@@ -51,6 +51,8 @@ public:
     bool setSuccessMarks(AgentIDConstPtr agentId, const IdGrp& suceededEps);
     const DomainVariable* getDomainVariable(AgentIDConstPtr agentId, const std::string& sort) const;
 
+    void setTeamTimeout(AlicaTime t);
+
 private:
     AlicaTime _teamTimeOut;
     Agent* _localAgent;

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -44,6 +44,7 @@ AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, cons
         , _masterPlan(_planParser.parsePlanTree(masterPlanName))
         , _roleSet(_planParser.parseRoleSet(roleSetName))
         , _roleAssignment(std::make_unique<StaticRoleAssignment>(this))
+        , _alicaClock(std::make_unique<AlicaClock>())
 {
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     PartialAssignment::allowIdling(sc["Alica"]->get<bool>("Alica.AllowIdling", NULL));

--- a/alica_engine/src/engine/RunningPlan.cpp
+++ b/alica_engine/src/engine/RunningPlan.cpp
@@ -673,10 +673,6 @@ bool RunningPlan::recursiveUpdateAssignment(const std::vector<const SimplePlanTr
             rem.clear();
             AssignmentView robs = _assignment.getAgentsWorking(i);
             for (AgentIDConstPtr rob : robs) {
-                const bool freezeAgent = keepState && _assignment.getStateOfAgent(rob) == getActiveState();
-                if (freezeAgent) {
-                    continue;
-                }
                 if (std::find(availableAgents.begin(), availableAgents.end(), rob) == availableAgents.end()) {
                     rem.push_back(rob);
                     aldif.editSubtractions().emplace_back(ep, rob);

--- a/alica_engine/src/engine/RunningPlan.cpp
+++ b/alica_engine/src/engine/RunningPlan.cpp
@@ -47,6 +47,11 @@ void RunningPlan::init()
             AlicaTime::milliseconds((essentials::SystemConfig::getInstance())["Alica"]->get<unsigned long>("Alica.AssignmentProtectionTime", NULL));
 }
 
+void RunningPlan::setAssignmentProtectionTime(AlicaTime t)
+{
+    s_assignmentProtectionTime = t;
+}
+
 RunningPlan::RunningPlan(AlicaEngine* ae)
         : _ae(ae)
         , _planType(nullptr)
@@ -673,6 +678,10 @@ bool RunningPlan::recursiveUpdateAssignment(const std::vector<const SimplePlanTr
             rem.clear();
             AssignmentView robs = _assignment.getAgentsWorking(i);
             for (AgentIDConstPtr rob : robs) {
+                /*const bool freezeAgent = keepState && _assignment.getStateOfAgent(rob) == getActiveState();
+                if (freezeAgent) {
+                    continue;
+                }*/
                 if (std::find(availableAgents.begin(), availableAgents.end(), rob) == availableAgents.end()) {
                     rem.push_back(rob);
                     aldif.editSubtractions().emplace_back(ep, rob);

--- a/alica_engine/src/engine/RunningPlan.cpp
+++ b/alica_engine/src/engine/RunningPlan.cpp
@@ -678,10 +678,6 @@ bool RunningPlan::recursiveUpdateAssignment(const std::vector<const SimplePlanTr
             rem.clear();
             AssignmentView robs = _assignment.getAgentsWorking(i);
             for (AgentIDConstPtr rob : robs) {
-                /*const bool freezeAgent = keepState && _assignment.getStateOfAgent(rob) == getActiveState();
-                if (freezeAgent) {
-                    continue;
-                }*/
                 if (std::find(availableAgents.begin(), availableAgents.end(), rob) == availableAgents.end()) {
                     rem.push_back(rob);
                     aldif.editSubtractions().emplace_back(ep, rob);

--- a/alica_engine/src/engine/TeamObserver.cpp
+++ b/alica_engine/src/engine/TeamObserver.cpp
@@ -1,4 +1,5 @@
 #include "engine/TeamObserver.h"
+
 #include "engine/AlicaEngine.h"
 #include "engine/Assignment.h"
 #include "engine/IAlicaCommunication.h"
@@ -75,6 +76,7 @@ bool TeamObserver::updateTeamPlanTrees()
 void TeamObserver::tick(RunningPlan* root)
 {
     AlicaTime time = _ae->getAlicaClock().now();
+    ALICA_DEBUG_MSG("TO: tick " << time);
 
     bool someChanges = updateTeamPlanTrees();
     // notifications for teamchanges, you can add some code below if you want to be notified when the team changed
@@ -275,6 +277,7 @@ void TeamObserver::handlePlanTreeInfo(std::shared_ptr<PlanTreeInfo> incoming)
             return;
         }
         lock_guard<mutex> lock(_msgQueueMutex);
+        ALICA_DEBUG_MSG("TO: Message received " << _ae->getAlicaClock().now());
         _msgQueue.emplace_back(std::move(incoming), _ae->getAlicaClock().now());
     }
 }

--- a/alica_engine/src/engine/teammanager/Agent.cpp
+++ b/alica_engine/src/engine/teammanager/Agent.cpp
@@ -47,6 +47,11 @@ void Agent::setLocal(bool local)
     _local = local;
 }
 
+void Agent::setTimeout(AlicaTime t)
+{
+    _timeout = t;
+}
+
 void Agent::setSuccess(const AbstractPlan* plan, const EntryPoint* entryPoint)
 {
     _engineData.editSuccessMarks().markSuccessfull(plan, entryPoint);

--- a/alica_engine/src/engine/teammanager/TeamManager.cpp
+++ b/alica_engine/src/engine/teammanager/TeamManager.cpp
@@ -31,6 +31,14 @@ TeamManager::~TeamManager()
     }
 }
 
+void TeamManager::setTeamTimeout(AlicaTime t)
+{
+    _teamTimeOut = t;
+    for (auto& agentEntry : _agents) {
+        agentEntry.second->setTimeout(t);
+    }
+}
+
 void TeamManager::readTeamFromConfig()
 {
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();

--- a/alica_tests/CMakeLists.txt
+++ b/alica_tests/CMakeLists.txt
@@ -59,6 +59,7 @@ if (CATKIN_ENABLE_TESTING)
         src/test/test_task_assignment.cpp
         src/test/test_variant.cpp
         src/test/test_varsync.cpp
+        src/test/test_agent_dies.cpp
     )
 
     add_rostest_gtest(${PROJECT_NAME}-test test/alica_tests.test ${test_alica_SOURCES})

--- a/alica_tests/autogenerated/include/TestWorldModel.h
+++ b/alica_tests/autogenerated/include/TestWorldModel.h
@@ -41,6 +41,8 @@ public:
     essentials::ITrigger* trigger1;
     essentials::ITrigger* trigger2;
 
+    void reset();
+
 private:
     TestWorldModel();
     bool transitionCondition1413201227586;

--- a/alica_tests/autogenerated/src/TestWorldModel.cpp
+++ b/alica_tests/autogenerated/src/TestWorldModel.cpp
@@ -28,24 +28,29 @@ TestWorldModel::TestWorldModel()
         : trigger1(new essentials::EventTrigger())
         , trigger2(new essentials::EventTrigger())
 {
-    this->transitionCondition1413201227586 = false;
-    this->transitionCondition1413201389955 = false;
-    this->transitionCondition1413201052549 = false;
-    this->transitionCondition1413201367990 = false;
-    this->transitionCondition1413201370590 = false;
-    this->preCondition1418042929966 = false;
-    this->runtimeCondition1418042967134 = false;
-
-    this->transitionCondition1418825427317 = false;
-    this->transitionCondition1418825428924 = false;
-
-    this->x = 0;
+    reset();
 }
 
 TestWorldModel::~TestWorldModel()
 {
     delete trigger1;
     delete trigger2;
+}
+
+void TestWorldModel::reset()
+{
+    transitionCondition1413201227586 = false;
+    transitionCondition1413201389955 = false;
+    transitionCondition1413201052549 = false;
+    transitionCondition1413201367990 = false;
+    transitionCondition1413201370590 = false;
+    preCondition1418042929966 = false;
+    runtimeCondition1418042967134 = false;
+
+    transitionCondition1418825427317 = false;
+    transitionCondition1418825428924 = false;
+
+    x = 0;
 }
 
 bool TestWorldModel::isTransitionCondition1413201227586()

--- a/alica_tests/include/test_alica.h
+++ b/alica_tests/include/test_alica.h
@@ -5,6 +5,7 @@
 #include "ConstraintCreator.h"
 #include "ConstraintTestPlanDummySolver.h"
 #include "UtilityFunctionCreator.h"
+#include <TestWorldModel.h>
 
 #include <communication/AlicaDummyCommunication.h>
 #include <engine/AlicaContext.h>
@@ -44,6 +45,9 @@ protected:
     virtual bool stepEngine() const { return true; }
     void SetUp() override
     {
+        alicaTests::TestWorldModel::getOne()->reset();
+        alicaTests::TestWorldModel::getTwo()->reset();
+
         // determine the path to the test config
         ros::NodeHandle nh;
         std::string path;
@@ -99,6 +103,8 @@ protected:
     virtual const char* getHostName(int agentNumber) const { return "nase"; }
     void SetUp() override
     {
+        alicaTests::TestWorldModel::getOne()->reset();
+        alicaTests::TestWorldModel::getTwo()->reset();
         // determine the path to the test config
         ros::NodeHandle nh;
         std::string path;

--- a/alica_tests/src/test/test_agent_dies.cpp
+++ b/alica_tests/src/test/test_agent_dies.cpp
@@ -1,0 +1,144 @@
+#include <engine/AlicaClock.h>
+#include <engine/AlicaEngine.h>
+#include <engine/IAlicaCommunication.h>
+#include <engine/model/Task.h>
+#include <gtest/gtest.h>
+#include <test_alica.h>
+
+#include "TestWorldModel.h"
+#include "engine/PlanBase.h"
+#include "engine/TeamObserver.h"
+#include "engine/model/Plan.h"
+#include "engine/model/State.h"
+#include "engine/teammanager/TeamManager.h"
+#include <communication/AlicaDummyCommunication.h>
+
+namespace alica
+{
+namespace
+{
+
+class AlicaEngineAgentDiesTest : public AlicaTestMultiAgentFixture
+{
+protected:
+    const int agentCount = 2;
+    const char* getRoleSetName() const override { return "RolesetTA"; }
+    const char* getMasterPlanName() const override { return "MultiAgentTestMaster"; }
+    int getAgentCount() const override { return agentCount; }
+    const char* getHostName(int agentNumber) const override
+    {
+        if (agentNumber) {
+            return "hairy";
+        } else {
+            return "nase";
+        }
+    }
+};
+
+class TestClock : public AlicaClock
+{
+public:
+    TestClock()
+            : _now()
+    {
+    }
+    AlicaTime now() const override { return _now; }
+    void increment(AlicaTime t) { _now += t; }
+
+private:
+    AlicaTime _now;
+};
+
+TEST_F(AlicaEngineAgentDiesTest, AgentIsRemoved)
+{
+    ASSERT_NO_SIGNAL
+
+    TestClock* c1 = new TestClock();
+    TestClock* c2 = new TestClock();
+    c1->increment(AlicaTime::hours(24));
+    c2->increment(AlicaTime::hours(24));
+    aes[0]->setAlicaClock(std::unique_ptr<AlicaClock>(c1));
+    aes[1]->setAlicaClock(std::unique_ptr<AlicaClock>(c2));
+
+    aes[0]->start();
+    aes[1]->start();
+    RunningPlan::setAssignmentProtectionTime(AlicaTime::seconds(1000.0));
+    aes[0]->editTeamManager().setTeamTimeout(AlicaTime::milliseconds(250));
+    aes[1]->editTeamManager().setTeamTimeout(AlicaTime::milliseconds(250));
+    step(aes[0]);
+    step(aes[1]);
+    c1->increment(AlicaTime::milliseconds(50));
+    c2->increment(AlicaTime::milliseconds(50));
+
+    alicaTests::TestWorldModel::getOne()->setTransitionCondition1413201227586(true);
+    alicaTests::TestWorldModel::getTwo()->setTransitionCondition1413201227586(true);
+
+    step(aes[0]);
+    step(aes[1]);
+    c1->increment(AlicaTime::milliseconds(50));
+    c2->increment(AlicaTime::milliseconds(50));
+
+    ASSERT_EQ(aes[0]->getPlanBase().getRootNode()->getActiveState()->getId(), 1413201213955);
+    ASSERT_EQ(aes[1]->getPlanBase().getRootNode()->getActiveState()->getId(), 1413201213955);
+
+    ASSERT_EQ(2, aes[0]->getTeamManager().getActiveAgentIds().size());
+    ASSERT_EQ(2, aes[1]->getTeamManager().getActiveAgentIds().size());
+
+    ASSERT_EQ(aes[0]->getPlanBase().getRootNode()->getChildren()[0]->getActivePlan()->getId(), 1413200862180);
+    ASSERT_EQ(aes[1]->getPlanBase().getRootNode()->getChildren()[0]->getActivePlan()->getId(), 1413200862180);
+
+    ASSERT_EQ(2, aes[0]->getPlanBase().getRootNode()->getChildren()[0]->getAssignment().size());
+    ASSERT_EQ(2, aes[1]->getPlanBase().getRootNode()->getChildren()[0]->getAssignment().size());
+
+    const_cast<IAlicaCommunication&>(aes[0]->getCommunicator()).stopCommunication();
+    const_cast<IAlicaCommunication&>(aes[1]->getCommunicator()).stopCommunication();
+
+    step(aes[0]);
+    step(aes[1]);
+    c1->increment(AlicaTime::milliseconds(2000));
+    c2->increment(AlicaTime::milliseconds(2000));
+
+    step(aes[0]);
+    step(aes[1]);
+
+    c1->increment(AlicaTime::milliseconds(50));
+    c2->increment(AlicaTime::milliseconds(50));
+
+    step(aes[0]);
+    step(aes[1]);
+
+    ASSERT_EQ(1, aes[0]->getTeamManager().getActiveAgentIds().size());
+    ASSERT_EQ(1, aes[1]->getTeamManager().getActiveAgentIds().size());
+
+    ASSERT_EQ(0, aes[0]->getPlanBase().getRootNode()->getChildren().size());
+    ASSERT_EQ(0, aes[1]->getPlanBase().getRootNode()->getChildren().size());
+
+    const_cast<IAlicaCommunication&>(aes[0]->getCommunicator()).startCommunication();
+    const_cast<IAlicaCommunication&>(aes[1]->getCommunicator()).startCommunication();
+
+    c1->increment(AlicaTime::milliseconds(50));
+    c2->increment(AlicaTime::milliseconds(50));
+
+    step(aes[0]);
+    step(aes[1]);
+
+    c1->increment(AlicaTime::milliseconds(50));
+    c2->increment(AlicaTime::milliseconds(50));
+
+    step(aes[0]);
+    step(aes[1]);
+
+    c1->increment(AlicaTime::milliseconds(50));
+    c2->increment(AlicaTime::milliseconds(50));
+
+    step(aes[0]);
+    step(aes[1]);
+
+    ASSERT_EQ(2, aes[0]->getTeamManager().getActiveAgentIds().size());
+    ASSERT_EQ(2, aes[1]->getTeamManager().getActiveAgentIds().size());
+
+    ASSERT_EQ(2, aes[0]->getPlanBase().getRootNode()->getChildren()[0]->getAssignment().size());
+    ASSERT_EQ(2, aes[1]->getPlanBase().getRootNode()->getChildren()[0]->getAssignment().size());
+}
+}
+}


### PR DESCRIPTION
The test adds some abilities to change parameters at runtime.
The clock needs to be changeable to support simulation clocks 

