### PR TITLE
Change getCurrentState() api to isStateActive() in AlicaContext

### DIFF
--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -218,11 +218,12 @@ public:
     bool isValid();
 
     /**
-     * Returns id for the last of currently active state of engine.
+     * Checks if the state identified by id is currently active.
+     * This method should be used only when engine is trigger based.
      *
-     * @return "0" if engine is in invalid state or "state id" as per plan.
+     * @return True if the state identified by id is currently active, false otherwise
      */
-    int64_t getCurrentState() const;
+    bool isStateActive(int64_t id) const;
 
     /**
      * Returns agent id for this alica context.

--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -246,6 +246,8 @@ public:
 private:
     friend class AlicaTestEngineGetter;
 
+    static bool isStateActiveHelper(const RunningPlan* rp, int64_t id);
+
     uint32_t _validTag;
     std::unique_ptr<AlicaEngine> _engine;
     std::unique_ptr<IAlicaCommunication> _communicator;

--- a/alica_engine/src/engine/AlicaContext.cpp
+++ b/alica_engine/src/engine/AlicaContext.cpp
@@ -53,7 +53,7 @@ bool AlicaContext::isValid()
     return _validTag == ALICA_CTX_GOOD;
 }
 
-bool isStateActiveHelper(const RunningPlan* rp, int64_t id)
+bool AlicaContext::isStateActiveHelper(const RunningPlan* rp, int64_t id)
 {
     if (!rp) {
         return false;
@@ -73,6 +73,7 @@ bool isStateActiveHelper(const RunningPlan* rp, int64_t id)
 
 bool AlicaContext::isStateActive(int64_t id) const
 {
+    // This method should be used only when engine is trigger based
     assert(_engine->getStepEngine());
     return isStateActiveHelper(_engine->getPlanBase().getRootNode(), id);
 }

--- a/alica_engine/src/engine/AlicaContext.cpp
+++ b/alica_engine/src/engine/AlicaContext.cpp
@@ -53,19 +53,28 @@ bool AlicaContext::isValid()
     return _validTag == ALICA_CTX_GOOD;
 }
 
-int64_t AlicaContext::getCurrentState() const
+bool isStateActiveHelper(const RunningPlan* rp, int64_t id)
 {
-    const RunningPlan* deepestPlan = _engine->getPlanBase().getDeepestNode();
-    if (!deepestPlan) {
-        return 0;
+    if (!rp) {
+        return false;
     }
-
-    const State* deepestState = deepestPlan->getActiveState();
-    if (!deepestState) {
-        return 0;
+    const State* activeState = rp->getActiveState();
+    if (activeState && activeState->getId() == id) {
+        return true;
     }
+    const std::vector<RunningPlan*>& children = rp->getChildren();
+    for (int i = 0; i < static_cast<int>(children.size()); ++i) {
+        if (isStateActiveHelper(children[i], id)) {
+            return true;
+        }
+    }
+    return false;
+}
 
-    return deepestState->getId();
+bool AlicaContext::isStateActive(int64_t id) const
+{
+    assert(_engine->getStepEngine());
+    return isStateActiveHelper(_engine->getPlanBase().getRootNode(), id);
 }
 
 void AlicaContext::stepEngine()


### PR DESCRIPTION
getCurrentState() returns only the active state in the deepest alica plan
tree node. Other active states cannot be known using this method. Therefore
change the api to isStateActive() which can check if a given state is active
in the entire current plan tree.