### PR TITLE
Provides a Ros clock API for running simulation faster than real time.

### DIFF
--- a/alica_engine/include/engine/AlicaClock.h
+++ b/alica_engine/include/engine/AlicaClock.h
@@ -135,9 +135,6 @@ public:
     virtual ~AlicaClock() {};
     virtual AlicaTime now() const;
     virtual void sleep(const AlicaTime&) const;
-
-protected:
-    AlicaEngine* ae;
 };
 
 } // namespace alica

--- a/alica_engine/include/engine/AlicaClock.h
+++ b/alica_engine/include/engine/AlicaClock.h
@@ -5,7 +5,6 @@
 
 namespace alica
 {
-class AlicaEngine;
 
 class AlicaTime
 {
@@ -129,8 +128,6 @@ private:
 class AlicaClock
 {
 public:
-    AlicaClock(AlicaEngine* ae)
-    :ae(ae) {};
     AlicaClock () {};
     virtual ~AlicaClock() {};
     virtual AlicaTime now() const;

--- a/alica_engine/include/engine/AlicaClock.h
+++ b/alica_engine/include/engine/AlicaClock.h
@@ -5,6 +5,7 @@
 
 namespace alica
 {
+class AlicaEngine;
 
 class AlicaTime
 {
@@ -128,10 +129,15 @@ private:
 class AlicaClock
 {
 public:
-    AlicaClock() {}
-    virtual ~AlicaClock() {}
+    AlicaClock(AlicaEngine* ae)
+    :ae(ae) {};
+    AlicaClock () {};
+    virtual ~AlicaClock() {};
     virtual AlicaTime now() const;
-    void sleep(const AlicaTime&) const;
+    virtual void sleep(const AlicaTime&) const;
+
+protected:
+    AlicaEngine* ae;
 };
 
 } // namespace alica

--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -277,9 +277,9 @@ void AlicaContext::setClock(Args&&... args)
 {
     static_assert(std::is_base_of<AlicaClock, ClockType>::value, "Must be derived from AlicaClock");
 #if (defined __cplusplus && __cplusplus >= 201402L)
-    _clock = std::make_unique<ClockType>(_engine.get(), std::forward<Args>(args)...);
+    _clock = std::make_unique<ClockType>(std::forward<Args>(args)...);
 #else
-    _clock = std::unique_ptr<ClockType>(new ClockType(_engine.get(), std::forward<Args>(args)...));
+    _clock = std::unique_ptr<ClockType>(new ClockType(std::forward<Args>(args)...));
 #endif
 }
 

--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -166,7 +166,7 @@ public:
     void setClock(Args&&... args);
 
     /**
-     * Get communicator being used by this alica instance.
+     * Get clock being used by this alica instance.
      *
      * @return A reference to alica clock object being used by context
      */

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -80,9 +80,6 @@ public:
     const TeamObserver& getTeamObserver() const { return _teamObserver; }
     TeamObserver& editTeamObserver() { return _teamObserver; }
 
-    const AlicaClock& getAlicaClock() const { return *_alicaClock.get(); }
-    void setAlicaClock(std::unique_ptr<AlicaClock> c) { _alicaClock = std::move(c); }
-
     const BlackBoard& getBlackBoard() const { return _blackboard; }
     BlackBoard& editBlackBoard() { return _blackboard; }
 
@@ -97,6 +94,7 @@ public:
 
     // AlicaContext forward interface
     const IAlicaCommunication& getCommunicator() const;
+    const AlicaClock& getAlicaClock() const;
     std::string getRobotName() const;
     template <class SolverType>
     SolverType& getSolver() const;

--- a/alica_engine/src/engine/AlicaContext.cpp
+++ b/alica_engine/src/engine/AlicaContext.cpp
@@ -16,6 +16,7 @@ constexpr int ALICA_LOOP_TIME_ESTIMATE = 33; // ms
 AlicaContext::AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine)
         : _validTag(ALICA_CTX_GOOD)
         , _engine(std::make_unique<AlicaEngine>(*this, roleSetName, masterPlanName, stepEngine))
+        , _clock(std::make_unique<AlicaClock>())
 {
 }
 

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -44,7 +44,6 @@ AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, cons
         , _masterPlan(_planParser.parsePlanTree(masterPlanName))
         , _roleSet(_planParser.parseRoleSet(roleSetName))
         , _roleAssignment(std::make_unique<StaticRoleAssignment>(this))
-        , _alicaClock(std::make_unique<AlicaClock>())
 {
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     PartialAssignment::allowIdling(sc["Alica"]->get<bool>("Alica.AllowIdling", NULL));
@@ -119,6 +118,11 @@ void AlicaEngine::terminate()
 const IAlicaCommunication& AlicaEngine::getCommunicator() const
 {
     return _ctx.getCommunicator();
+}
+
+const AlicaClock& AlicaEngine::getAlicaClock() const
+{
+    return _ctx.getAlicaClock();
 }
 
 std::string AlicaEngine::getRobotName() const

--- a/alica_tests/src/test/test_agent_dies.cpp
+++ b/alica_tests/src/test/test_agent_dies.cpp
@@ -55,8 +55,8 @@ TEST_F(AlicaEngineAgentDiesTest, AgentIsRemoved)
 
     TestClock* c1 = new TestClock();
     TestClock* c2 = new TestClock();
-    aes[0]->setAlicaClock(std::unique_ptr<AlicaClock>(c1));
-    aes[1]->setAlicaClock(std::unique_ptr<AlicaClock>(c2));
+    acs[0]->setClock<std::unique_ptr<AlicaClock>(c1);
+    acs[1]->setClock<std::unique_ptr<AlicaClock>(c2);
 
     aes[0]->start();
     aes[1]->start();


### PR DESCRIPTION
In some application like where the user requires a clock faster than real-time for simulations.
* Problems
  * If ros clock accelerates too much faster than real-time then task done by regular Alica clock will be running at the same rate and will cause weird behavior.
