### PR TITLE
Provide api in AlicaContext to use a custom clock

### DIFF
--- a/alica_engine/include/engine/AlicaClock.h
+++ b/alica_engine/include/engine/AlicaClock.h
@@ -131,7 +131,7 @@ public:
     AlicaClock() {}
     virtual ~AlicaClock() {}
     virtual AlicaTime now() const;
-    void sleep(const AlicaTime&) const;
+    virtual void sleep(const AlicaTime&) const;
 };
 
 } // namespace alica

--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -157,6 +157,26 @@ public:
     int terminate();
 
     /**
+     * Set Alica Clock choose between RosClock or systemClock (std::chrono)
+     * 
+     * @note ClockType must be a derived class of AlicaClock
+     * @note This must be called before initializing context
+     */
+    template <class ClockType, class... Args>
+    void setClock(Args&&... args);
+
+    /**
+     * Get clock being used by this alica instance.
+     *
+     * @return A reference to alica clock object being used by context
+     */
+    const AlicaClock& getAlicaClock() const
+    {
+        assert(_clock.get());
+        return *_clock;
+    }
+
+    /**
      * Set communicator to be used by this alica framework instance.
      * Example usage: setCommunicator<alicaDummyProxy::AlicaDummyCommunication>();
      *
@@ -252,7 +272,19 @@ private:
     std::unique_ptr<AlicaEngine> _engine;
     std::unique_ptr<IAlicaCommunication> _communicator;
     std::unordered_map<size_t, std::unique_ptr<ISolverBase>> _solvers;
+    std::unique_ptr<AlicaClock> _clock;
 };
+
+template <class ClockType, class... Args>
+void AlicaContext::setClock(Args&&... args)
+{
+    static_assert(std::is_base_of<AlicaClock, ClockType>::value, "Must be derived from AlicaClock");
+#if (defined __cplusplus && __cplusplus >= 201402L)
+    _clock = std::make_unique<ClockType>(std::forward<Args>(args)...);
+#else
+    _clock = std::unique_ptr<ClockType>(new ClockType(std::forward<Args>(args)...));
+#endif
+}
 
 template <class CommunicatorType, class... Args>
 void AlicaContext::setCommunicator(Args&&... args)

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -80,9 +80,6 @@ public:
     const TeamObserver& getTeamObserver() const { return _teamObserver; }
     TeamObserver& editTeamObserver() { return _teamObserver; }
 
-    const AlicaClock& getAlicaClock() const { return *_alicaClock.get(); }
-    void setAlicaClock(std::unique_ptr<AlicaClock> c) { _alicaClock = std::move(c); }
-
     const BlackBoard& getBlackBoard() const { return _blackboard; }
     BlackBoard& editBlackBoard() { return _blackboard; }
 
@@ -97,6 +94,7 @@ public:
 
     // AlicaContext forward interface
     const IAlicaCommunication& getCommunicator() const;
+    const AlicaClock& getAlicaClock() const;
     std::string getRobotName() const;
     template <class SolverType>
     SolverType& getSolver() const;

--- a/alica_engine/src/engine/AlicaContext.cpp
+++ b/alica_engine/src/engine/AlicaContext.cpp
@@ -16,6 +16,7 @@ constexpr int ALICA_LOOP_TIME_ESTIMATE = 33; // ms
 AlicaContext::AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine)
         : _validTag(ALICA_CTX_GOOD)
         , _engine(std::make_unique<AlicaEngine>(*this, roleSetName, masterPlanName, stepEngine))
+        , _clock(std::make_unique<AlicaClock>())
 {
 }
 

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -44,7 +44,6 @@ AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, cons
         , _masterPlan(_planParser.parsePlanTree(masterPlanName))
         , _roleSet(_planParser.parseRoleSet(roleSetName))
         , _roleAssignment(std::make_unique<StaticRoleAssignment>(this))
-        , _alicaClock(std::make_unique<AlicaClock>())
 {
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     PartialAssignment::allowIdling(sc["Alica"]->get<bool>("Alica.AllowIdling", NULL));
@@ -119,6 +118,11 @@ void AlicaEngine::terminate()
 const IAlicaCommunication& AlicaEngine::getCommunicator() const
 {
     return _ctx.getCommunicator();
+}
+
+const AlicaClock& AlicaEngine::getAlicaClock() const
+{
+    return _ctx.getAlicaClock();
 }
 
 std::string AlicaEngine::getRobotName() const

--- a/alica_tests/src/test/test_agent_dies.cpp
+++ b/alica_tests/src/test/test_agent_dies.cpp
@@ -49,14 +49,17 @@ private:
     AlicaTime _now;
 };
 
+inline TestClock& getTestClock(AlicaContext* ac)
+{
+    return static_cast<TestClock&>(const_cast<AlicaClock&>(ac->getAlicaClock()));
+}
+
 TEST_F(AlicaEngineAgentDiesTest, AgentIsRemoved)
 {
     ASSERT_NO_SIGNAL
 
-    TestClock* c1 = new TestClock();
-    TestClock* c2 = new TestClock();
-    aes[0]->setAlicaClock(std::unique_ptr<AlicaClock>(c1));
-    aes[1]->setAlicaClock(std::unique_ptr<AlicaClock>(c2));
+    acs[0]->setClock<TestClock>();
+    acs[1]->setClock<TestClock>();
 
     aes[0]->start();
     aes[1]->start();
@@ -71,16 +74,16 @@ TEST_F(AlicaEngineAgentDiesTest, AgentIsRemoved)
     aes[1]->editTeamManager().setTeamTimeout(AlicaTime::milliseconds(500));
     step(aes[0]);
     step(aes[1]);
-    c1->increment(AlicaTime::milliseconds(50));
-    c2->increment(AlicaTime::milliseconds(50));
+    getTestClock(acs[0]).increment(AlicaTime::milliseconds(50));
+    getTestClock(acs[1]).increment(AlicaTime::milliseconds(50));
 
     alicaTests::TestWorldModel::getOne()->setTransitionCondition1413201227586(true);
     alicaTests::TestWorldModel::getTwo()->setTransitionCondition1413201227586(true);
 
     step(aes[0]);
     step(aes[1]);
-    c1->increment(AlicaTime::milliseconds(50));
-    c2->increment(AlicaTime::milliseconds(50));
+    getTestClock(acs[0]).increment(AlicaTime::milliseconds(50));
+    getTestClock(acs[1]).increment(AlicaTime::milliseconds(50));
 
     ASSERT_EQ(aes[0]->getPlanBase().getRootNode()->getActiveState()->getId(), 1413201213955);
     ASSERT_EQ(aes[1]->getPlanBase().getRootNode()->getActiveState()->getId(), 1413201213955);
@@ -99,14 +102,14 @@ TEST_F(AlicaEngineAgentDiesTest, AgentIsRemoved)
 
     step(aes[0]);
     step(aes[1]);
-    c1->increment(AlicaTime::milliseconds(2000));
-    c2->increment(AlicaTime::milliseconds(2000));
+    getTestClock(acs[0]).increment(AlicaTime::milliseconds(2000));
+    getTestClock(acs[1]).increment(AlicaTime::milliseconds(2000));
 
     step(aes[0]);
     step(aes[1]);
 
-    c1->increment(AlicaTime::milliseconds(50));
-    c2->increment(AlicaTime::milliseconds(50));
+    getTestClock(acs[0]).increment(AlicaTime::milliseconds(50));
+    getTestClock(acs[1]).increment(AlicaTime::milliseconds(50));
 
     step(aes[0]);
     step(aes[1]);
@@ -120,20 +123,20 @@ TEST_F(AlicaEngineAgentDiesTest, AgentIsRemoved)
     const_cast<IAlicaCommunication&>(aes[0]->getCommunicator()).startCommunication();
     const_cast<IAlicaCommunication&>(aes[1]->getCommunicator()).startCommunication();
 
-    c1->increment(AlicaTime::milliseconds(50));
-    c2->increment(AlicaTime::milliseconds(50));
+    getTestClock(acs[0]).increment(AlicaTime::milliseconds(50));
+    getTestClock(acs[1]).increment(AlicaTime::milliseconds(50));
 
     step(aes[0]);
     step(aes[1]);
 
-    c1->increment(AlicaTime::milliseconds(50));
-    c2->increment(AlicaTime::milliseconds(50));
+    getTestClock(acs[0]).increment(AlicaTime::milliseconds(50));
+    getTestClock(acs[1]).increment(AlicaTime::milliseconds(50));
 
     step(aes[0]);
     step(aes[1]);
 
-    c1->increment(AlicaTime::milliseconds(50));
-    c2->increment(AlicaTime::milliseconds(50));
+    getTestClock(acs[0]).increment(AlicaTime::milliseconds(50));
+    getTestClock(acs[1]).increment(AlicaTime::milliseconds(50));
 
     step(aes[0]);
     step(aes[1]);


### PR DESCRIPTION
A custom clock is useful for simulations & testing in order to control the
speed of the simulation. This clock can be set in the AlicaContext and will
be used by the engine for time-based work.