### PR TITLE
Add agent idv0.9.0

### DIFF
--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -126,7 +126,7 @@ public:
      *
      * @note This is the main alica api class
      */
-    AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentID* agentID = nullptr);
+    AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, const AgentID* agentID = nullptr);
 
     /**
      * Destroys AlicaContext object.

--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -126,7 +126,7 @@ public:
      *
      * @note This is the main alica api class
      */
-    AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentIDConstPtr agentID = nullptr);
+    AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentID* agentID = nullptr);
 
     /**
      * Destroys AlicaContext object.

--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -17,6 +17,7 @@
 #include "engine/IUtilityCreator.h"
 #include "engine/constraintmodul/ISolver.h"
 #include "essentials/AgentID.h"
+#include "engine/AgentIDConstPtr.h"
 
 namespace alica
 {
@@ -125,7 +126,7 @@ public:
      *
      * @note This is the main alica api class
      */
-    AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine);
+    AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentIDConstPtr agentID = nullptr);
 
     /**
      * Destroys AlicaContext object.

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -33,7 +33,7 @@ public:
     template <typename T>
     static void abort(const std::string&, const T& tail);
 
-    AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentID* agentID = nullptr);
+    AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, const AgentID* agentID = nullptr);
     ~AlicaEngine();
 
     // State modifiers:

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -33,7 +33,7 @@ public:
     template <typename T>
     static void abort(const std::string&, const T& tail);
 
-    AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine);
+    AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentIDConstPtr agentID = nullptr);
     ~AlicaEngine();
 
     // State modifiers:

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <ros/ros.h>
+
 #include "engine/AgentIDConstPtr.h"
 #include "engine/AlicaContext.h"
 #include "engine/BehaviourPool.h"

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -33,7 +33,7 @@ public:
     template <typename T>
     static void abort(const std::string&, const T& tail);
 
-    AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentIDConstPtr agentID = nullptr);
+    AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentID* agentID = nullptr);
     ~AlicaEngine();
 
     // State modifiers:

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <ros/ros.h>
 #include "engine/AgentIDConstPtr.h"
 #include "engine/AlicaContext.h"
 #include "engine/BehaviourPool.h"

--- a/alica_engine/include/engine/teammanager/TeamManager.h
+++ b/alica_engine/include/engine/teammanager/TeamManager.h
@@ -82,11 +82,10 @@ private:
 
     Agent* _localAgent;
     AgentsCache _agentsCache;
-    AgentIDConstPtr _agentId;
     AlicaEngine* _engine;
     bool _useAutoDiscovery;
 
-    void readSelfFromConfig();
+    void readSelfFromConfig(AgentIDConstPtr agentID);
     void announcePresence() const;
     void queryPresence() const;
     Agent* getAgent(AgentIDConstPtr agentId) const;

--- a/alica_engine/include/engine/teammanager/TeamManager.h
+++ b/alica_engine/include/engine/teammanager/TeamManager.h
@@ -45,7 +45,7 @@ private:
 class TeamManager
 {
 public:
-    TeamManager(AlicaEngine* engine);
+    TeamManager(AlicaEngine* engine, AgentIDConstPtr agentID = nullptr);
     virtual ~TeamManager();
 
     AgentIDConstPtr getLocalAgentID() const;
@@ -82,6 +82,7 @@ private:
 
     Agent* _localAgent;
     AgentsCache _agentsCache;
+    AgentIDConstPtr _agentId;
     AlicaEngine* _engine;
     bool _useAutoDiscovery;
 

--- a/alica_engine/src/engine/AlicaContext.cpp
+++ b/alica_engine/src/engine/AlicaContext.cpp
@@ -13,7 +13,7 @@ constexpr uint32_t ALICA_CTX_GOOD = 0xaac0ffee;
 constexpr uint32_t ALICA_CTX_BAD = 0xdeaddead;
 constexpr int ALICA_LOOP_TIME_ESTIMATE = 33; // ms
 
-AlicaContext::AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentID* agentID)
+AlicaContext::AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, const AgentID* agentID)
         : _validTag(ALICA_CTX_GOOD)
         , _engine(std::make_unique<AlicaEngine>(*this, roleSetName, masterPlanName, stepEngine, agentID))
         , _clock(std::make_unique<AlicaClock>())

--- a/alica_engine/src/engine/AlicaContext.cpp
+++ b/alica_engine/src/engine/AlicaContext.cpp
@@ -13,9 +13,9 @@ constexpr uint32_t ALICA_CTX_GOOD = 0xaac0ffee;
 constexpr uint32_t ALICA_CTX_BAD = 0xdeaddead;
 constexpr int ALICA_LOOP_TIME_ESTIMATE = 33; // ms
 
-AlicaContext::AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine)
+AlicaContext::AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentIDConstPtr agentID)
         : _validTag(ALICA_CTX_GOOD)
-        , _engine(std::make_unique<AlicaEngine>(*this, roleSetName, masterPlanName, stepEngine))
+        , _engine(std::make_unique<AlicaEngine>(*this, roleSetName, masterPlanName, stepEngine, agentID))
         , _clock(std::make_unique<AlicaClock>())
 {
 }

--- a/alica_engine/src/engine/AlicaContext.cpp
+++ b/alica_engine/src/engine/AlicaContext.cpp
@@ -1,4 +1,3 @@
-#include <ros/ros.h>
 #include <stdio.h>
 #include "engine/AlicaContext.h"
 #include "engine/AlicaEngine.h"
@@ -19,9 +18,6 @@ AlicaContext::AlicaContext(const std::string& roleSetName, const std::string& ma
         , _engine(std::make_unique<AlicaEngine>(*this, roleSetName, masterPlanName, stepEngine, agentID))
         , _clock(std::make_unique<AlicaClock>())
 {
-    ROS_INFO_STREAM("INSIDE AC CONSTRUCTOR");
-    ROS_INFO("[AC] AgentID received");
-    ROS_INFO_STREAM(*agentID);  
 }
 
 AlicaContext::~AlicaContext()

--- a/alica_engine/src/engine/AlicaContext.cpp
+++ b/alica_engine/src/engine/AlicaContext.cpp
@@ -13,7 +13,7 @@ constexpr uint32_t ALICA_CTX_GOOD = 0xaac0ffee;
 constexpr uint32_t ALICA_CTX_BAD = 0xdeaddead;
 constexpr int ALICA_LOOP_TIME_ESTIMATE = 33; // ms
 
-AlicaContext::AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentIDConstPtr agentID)
+AlicaContext::AlicaContext(const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentID* agentID)
         : _validTag(ALICA_CTX_GOOD)
         , _engine(std::make_unique<AlicaEngine>(*this, roleSetName, masterPlanName, stepEngine, agentID))
         , _clock(std::make_unique<AlicaClock>())

--- a/alica_engine/src/engine/AlicaContext.cpp
+++ b/alica_engine/src/engine/AlicaContext.cpp
@@ -1,4 +1,5 @@
-
+#include <ros/ros.h>
+#include <stdio.h>
 #include "engine/AlicaContext.h"
 #include "engine/AlicaEngine.h"
 
@@ -18,6 +19,9 @@ AlicaContext::AlicaContext(const std::string& roleSetName, const std::string& ma
         , _engine(std::make_unique<AlicaEngine>(*this, roleSetName, masterPlanName, stepEngine, agentID))
         , _clock(std::make_unique<AlicaClock>())
 {
+    ROS_INFO_STREAM("INSIDE AC CONSTRUCTOR");
+    ROS_INFO("[AC] AgentID received");
+    ROS_INFO_STREAM(*agentID);  
 }
 
 AlicaContext::~AlicaContext()

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -45,8 +45,6 @@ AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, cons
         , _roleSet(_planParser.parseRoleSet(roleSetName))
         , _roleAssignment(std::make_unique<StaticRoleAssignment>(this))
 {
-    ROS_INFO("[AC] AgentID received");
-    ROS_INFO_STREAM(*agentID);
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     PartialAssignment::allowIdling(sc["Alica"]->get<bool>("Alica.AllowIdling", NULL));
     _maySendMessages = !sc["Alica"]->get<bool>("Alica.SilentStart", NULL);

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -45,6 +45,8 @@ AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, cons
         , _roleSet(_planParser.parseRoleSet(roleSetName))
         , _roleAssignment(std::make_unique<StaticRoleAssignment>(this))
 {
+    ROS_INFO("[AC] AgentID received");
+    ROS_INFO_STREAM(*agentID);
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     PartialAssignment::allowIdling(sc["Alica"]->get<bool>("Alica.AllowIdling", NULL));
     _maySendMessages = !sc["Alica"]->get<bool>("Alica.SilentStart", NULL);

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -27,14 +27,14 @@ void AlicaEngine::abort(const std::string& msg)
 /**
  * The main class.
  */
-AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentIDConstPtr agentID)
+AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentID* agentID)
         : _ctx(ctx)
         , _stepCalled(false)
         , _log(this)
         , _stepEngine(stepEngine)
         , _agentIDManager(new essentials::AgentIDFactory())
         , _planParser(&_planRepository)
-        , _teamManager(this, agentID)
+        , _teamManager(this, _agentIDManager.getIDFromBytes(agentID->toByteVector()))
         , _syncModul(this)
         , _behaviourPool(this)
         , _teamObserver(this)

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -27,14 +27,14 @@ void AlicaEngine::abort(const std::string& msg)
 /**
  * The main class.
  */
-AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine)
+AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentIDConstPtr agentID)
         : _ctx(ctx)
         , _stepCalled(false)
         , _log(this)
         , _stepEngine(stepEngine)
         , _agentIDManager(new essentials::AgentIDFactory())
         , _planParser(&_planRepository)
-        , _teamManager(this)
+        , _teamManager(this, agentID)
         , _syncModul(this)
         , _behaviourPool(this)
         , _teamObserver(this)

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -27,14 +27,14 @@ void AlicaEngine::abort(const std::string& msg)
 /**
  * The main class.
  */
-AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, AgentID* agentID)
+AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine, const AgentID* agentID)
         : _ctx(ctx)
         , _stepCalled(false)
         , _log(this)
         , _stepEngine(stepEngine)
         , _agentIDManager(new essentials::AgentIDFactory())
         , _planParser(&_planRepository)
-        , _teamManager(this, _agentIDManager.getIDFromBytes(agentID->toByteVector()))
+        , _teamManager(this, (agentID != nullptr ? _agentIDManager.getIDFromBytes(agentID->toByteVector()) : nullptr))
         , _syncModul(this)
         , _behaviourPool(this)
         , _teamObserver(this)

--- a/alica_engine/src/engine/teammanager/TeamManager.cpp
+++ b/alica_engine/src/engine/teammanager/TeamManager.cpp
@@ -61,6 +61,10 @@ TeamManager::TeamManager(AlicaEngine* engine, AgentIDConstPtr agentID)
         , _announcementRetries(0)
         , _agentId(agentID)
 {
+    ROS_INFO("[TEAM MANAGER] AgentID received");
+    ROS_INFO_STREAM(*agentID);
+    ROS_INFO_STREAM("[TM] _agentId");
+    ROS_INFO_STREAM(*_agentId);
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     _teamTimeOut = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica.TeamTimeOut", NULL));
     _useAutoDiscovery = sc["Alica"]->get<bool>("Alica.AutoDiscovery", NULL);
@@ -85,10 +89,14 @@ void TeamManager::setTeamTimeout(AlicaTime t)
 
 void TeamManager::readSelfFromConfig()
 {
+    ROS_INFO("[TM] Inside readSelfFromConfig _agentId");
+    ROS_INFO_STREAM(*_agentId);
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     const std::string localAgentName = _engine->getRobotName();
 
     if (_agentId == nullptr) {
+        ROS_INFO("[TM] _agentId is a nullptr");
+        ROS_INFO_STREAM(*_agentId);
         constexpr auto notAValidID = std::numeric_limits<uint64_t>::max();
         uint64_t id = sc["Local"]->tryGet<uint64_t>(notAValidID, "Local", "ID", NULL);
         if (id != notAValidID) {
@@ -108,7 +116,12 @@ void TeamManager::readSelfFromConfig()
             }
         }
     } else {
-        _localAnnouncement.senderID = _engine->getId(_agentId);
+        ROS_INFO("[TM] Using received _agentId");
+        ROS_INFO_STREAM(*_agentId);
+        uint64_t id = *_agentId;
+        _localAnnouncement.senderID = _engine->getId(id);
+        ROS_INFO("[TM] _localAnnouncement.senderID");
+        ROS_INFO_STREAM(*_localAnnouncement.senderID);
     }
 
     std::random_device rd;

--- a/alica_engine/src/engine/teammanager/TeamManager.cpp
+++ b/alica_engine/src/engine/teammanager/TeamManager.cpp
@@ -61,10 +61,6 @@ TeamManager::TeamManager(AlicaEngine* engine, AgentIDConstPtr agentID)
         , _announcementRetries(0)
         , _agentId(agentID)
 {
-    ROS_INFO("[TEAM MANAGER] AgentID received");
-    ROS_INFO_STREAM(*agentID);
-    ROS_INFO_STREAM("[TM] _agentId");
-    ROS_INFO_STREAM(*_agentId);
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     _teamTimeOut = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica.TeamTimeOut", NULL));
     _useAutoDiscovery = sc["Alica"]->get<bool>("Alica.AutoDiscovery", NULL);
@@ -89,14 +85,10 @@ void TeamManager::setTeamTimeout(AlicaTime t)
 
 void TeamManager::readSelfFromConfig()
 {
-    ROS_INFO("[TM] Inside readSelfFromConfig _agentId");
-    ROS_INFO_STREAM(*_agentId);
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     const std::string localAgentName = _engine->getRobotName();
 
     if (_agentId == nullptr) {
-        ROS_INFO("[TM] _agentId is a nullptr");
-        ROS_INFO_STREAM(*_agentId);
         constexpr auto notAValidID = std::numeric_limits<uint64_t>::max();
         uint64_t id = sc["Local"]->tryGet<uint64_t>(notAValidID, "Local", "ID", NULL);
         if (id != notAValidID) {
@@ -116,12 +108,8 @@ void TeamManager::readSelfFromConfig()
             }
         }
     } else {
-        ROS_INFO("[TM] Using received _agentId");
-        ROS_INFO_STREAM(*_agentId);
         uint64_t id = *_agentId;
         _localAnnouncement.senderID = _engine->getId(id);
-        ROS_INFO("[TM] _localAnnouncement.senderID");
-        ROS_INFO_STREAM(*_localAnnouncement.senderID);
     }
 
     std::random_device rd;

--- a/alica_engine/src/engine/teammanager/TeamManager.cpp
+++ b/alica_engine/src/engine/teammanager/TeamManager.cpp
@@ -59,7 +59,6 @@ TeamManager::TeamManager(AlicaEngine* engine, AgentIDConstPtr agentID)
         , _agentAnnouncementTimeInterval(AlicaTime::zero())
         , _timeLastAnnouncement(AlicaTime::zero())
         , _announcementRetries(0)
-        , _agentId(agentID)
 {
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     _teamTimeOut = AlicaTime::milliseconds(sc["Alica"]->get<unsigned long>("Alica.TeamTimeOut", NULL));
@@ -68,7 +67,7 @@ TeamManager::TeamManager(AlicaEngine* engine, AgentIDConstPtr agentID)
         _agentAnnouncementTimeInterval = AlicaTime::seconds(sc["Alica"]->get<unsigned long>("Alica.AgentAnnouncementTimeInterval", NULL));
         _announcementRetries = sc["Alica"]->get<int>("Alica.AnnouncementRetries", NULL);
     }
-    readSelfFromConfig();
+    readSelfFromConfig(agentID);
 }
 
 TeamManager::~TeamManager() {}
@@ -83,12 +82,12 @@ void TeamManager::setTeamTimeout(AlicaTime t)
     }
 }
 
-void TeamManager::readSelfFromConfig()
+void TeamManager::readSelfFromConfig(AgentIDConstPtr agentID)
 {
     essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     const std::string localAgentName = _engine->getRobotName();
 
-    if (_agentId == nullptr) {
+    if (agentID == nullptr) {
         constexpr auto notAValidID = std::numeric_limits<uint64_t>::max();
         uint64_t id = sc["Local"]->tryGet<uint64_t>(notAValidID, "Local", "ID", NULL);
         if (id != notAValidID) {
@@ -108,8 +107,7 @@ void TeamManager::readSelfFromConfig()
             }
         }
     } else {
-        uint64_t id = *_agentId;
-        _localAnnouncement.senderID = _engine->getId(id);
+        _localAnnouncement.senderID = agentID;
     }
 
     std::random_device rd;


### PR DESCRIPTION
added a functionality to acquire agentid and default arg to AlicaContext, AlicaEngine and TeamManager Constructors 

If the agentid is null, only then does the TeamManager read it from Local.conf file or generate it. 
If the agentid is present (passed to AlicaContext), then the TeamManager does not bother doing the above. 