### PR TITLE
- no reference for agentid in teammanger

### DIFF
--- a/alica_engine/include/engine/teammanager/TeamManager.h
+++ b/alica_engine/include/engine/teammanager/TeamManager.h
@@ -95,7 +95,7 @@ private:
     AgentsCache _agentsCache;
     AlicaEngine* _engine;
     bool _useAutoDiscovery;
-    essentials::IdentifierConstPtr& _localAgentID;
+    essentials::IdentifierConstPtr _localAgentID;
 };
 
 class ActiveAgentBaseIterator : public std::iterator<std::forward_iterator_tag, essentials::IdentifierConstPtr>


### PR DESCRIPTION
I found a problem on coverity. I hope that fixes it.