### PR TITLE
- fixed path composition in AlicaContext and ModelManager

### DIFF
--- a/alica_engine/package.xml
+++ b/alica_engine/package.xml
@@ -2,10 +2,10 @@
 
 <package format="2">
   <name>alica_engine</name>
-  <version>0.0.1</version>
+  <version>0.9.1</version>
   <description>The alica_engine package</description>
-  <maintainer email="opfer@vs.uni-kassel.de">Stephan Opfer</maintainer>
-  <maintainer email="hendrik@rapyuta-robotics.com">hendrik</maintainer>
+  <maintainer email="stephan.opfer@rapyuta-robotics.com">Stephan Opfer</maintainer>
+  <maintainer email="abhishek.sharma@rapyuta-robotics.com">Abhishek Sharma</maintainer>
 
   <license>MIT</license>
 

--- a/alica_engine/src/engine/AlicaContext.cpp
+++ b/alica_engine/src/engine/AlicaContext.cpp
@@ -1,6 +1,7 @@
 #include "engine/AlicaContext.h"
 #include "engine/AlicaEngine.h"
 
+#include <essentials/FileSystem.h>
 #include <essentials/IdentifierConstPtr.h>
 
 namespace alica
@@ -89,17 +90,22 @@ std::string AlicaContext::getLocalAgentName() const
 YAML::Node AlicaContext::initConfig(const std::string& configPath, const std::string& agentName)
 {
     YAML::Node node;
+    std::string configFile;
+    std::cerr << "AC: configPath " << configPath << " agentName " << agentName << std::endl;
     try {
-        node = YAML::LoadFile(configPath + agentName + "/Alica.yaml");
+        configFile = essentials::FileSystem::combinePaths(configPath, agentName);
+        configFile = essentials::FileSystem::combinePaths(configFile, "Alica.yaml");
+        node = YAML::LoadFile(configFile);
         return node;
     } catch (YAML::BadFile& badFile) {
-        ALICA_WARNING_MSG("AC: Could not parse file: " << badFile.msg);
+        ALICA_WARNING_MSG("AC: Could not parse file: " << configFile << " - " << badFile.msg);
     }
 
     try {
-        node = YAML::LoadFile(configPath + "Alica.yaml");
+        configFile = essentials::FileSystem::combinePaths(configPath, "Alica.yaml");
+        node = YAML::LoadFile(configFile);
     } catch (YAML::BadFile& badFile) {
-        AlicaEngine::abort("AC: Could not parse file: ", badFile.msg);
+        AlicaEngine::abort("AC: Could not parse file: ", configFile + " - " + badFile.msg);
     }
 
     return node;

--- a/alica_engine/src/engine/AlicaContext.cpp
+++ b/alica_engine/src/engine/AlicaContext.cpp
@@ -91,7 +91,6 @@ YAML::Node AlicaContext::initConfig(const std::string& configPath, const std::st
 {
     YAML::Node node;
     std::string configFile;
-    std::cerr << "AC: configPath " << configPath << " agentName " << agentName << std::endl;
     try {
         configFile = essentials::FileSystem::combinePaths(configPath, agentName);
         configFile = essentials::FileSystem::combinePaths(configFile, "Alica.yaml");

--- a/alica_engine/src/engine/modelmanagement/ModelManager.cpp
+++ b/alica_engine/src/engine/modelmanagement/ModelManager.cpp
@@ -49,7 +49,7 @@ std::string ModelManager::getBasePath(const std::string& configKey)
     try {
         basePath = _ae->getConfig()["Alica"][configKey].as<std::string>();
     } catch (const std::runtime_error& error) {
-        AlicaEngine::abort("MM: Directory for config key " + configKey + " does not exist.\n", error.what());
+        AlicaEngine::abort("MM: Directory for config key '" + configKey + "' does not exist in the Alica config file.\n", error.what());
     }
 
     if (!essentials::FileSystem::endsWith(basePath, essentials::FileSystem::PATH_SEPARATOR)) {
@@ -57,14 +57,14 @@ std::string ModelManager::getBasePath(const std::string& configKey)
     }
 
     if (!essentials::FileSystem::isPathRooted(basePath)) {
-        basePath = domainConfigFolder + basePath;
+        basePath = essentials::FileSystem::combinePaths(domainConfigFolder, basePath);
     }
-
-    ALICA_INFO_MSG("MM: config key '" + configKey + "' maps to '" + basePath + "'");
 
     if (!essentials::FileSystem::pathExists(basePath)) {
-        AlicaEngine::abort("MM: base path does not exist: " + basePath);
+        AlicaEngine::abort("MM: Base path '" + basePath + "' does not exist for '" + configKey + "'");
     }
+
+    ALICA_INFO_MSG("MM: Config key '" + configKey + "' maps to '" + basePath + "'");
     return basePath;
 }
 


### PR DESCRIPTION
I needed to improve the composition of file paths, since the supplementary tests did not pass the paths as it was expected. Instead of fixing the hard coded path in tests, I decided to make the engine more robust and utilise our existing fsystem package here.