### PR TITLE
Fix/keep behaviour result for on terminate

### DIFF
--- a/alica_engine/src/engine/BasicBehaviour.cpp
+++ b/alica_engine/src/engine/BasicBehaviour.cpp
@@ -195,7 +195,7 @@ void BasicBehaviour::doStop()
 {
     // important to set stopCalled to false after setting behaviour result for correct lock-free
     // behaviour of isSuccess() & isFailure(). Should be called when _runLoopMutex is held by the thread
-    setBehaviourResult(BehaviourResult::UNKNOWN);
+//    setBehaviourResult(BehaviourResult::UNKNOWN);
     setBehaviourState(BehaviourState::TERMINATING);
     setStopCalled(false);
 }

--- a/alica_engine/src/engine/RunningPlan.cpp
+++ b/alica_engine/src/engine/RunningPlan.cpp
@@ -285,6 +285,8 @@ void RunningPlan::usePlan(const AbstractPlan* plan)
         revokeAllConstraints();
         _activeTriple.abstractPlan = plan;
         _status.runTimeConditionStatus = EvalStatus::Unknown;
+    } else if (_status.planStartTime == AlicaTime::zero()) {
+        _status.planStartTime = _ae->getAlicaClock().now();
     }
 }
 


### PR DESCRIPTION
This PR does two things:
* keeps the behaviour result to be available in the behaviours onTerminate function
* correctly sets the "planStartTime" for behaviours (before it wasn't set because the abstract plan was given via the constructor of the RunningPlan in case of a behaviour)