### PR TITLE
Track RunningPlan in beh, plan's exec context + optimize

### DIFF
--- a/alica_engine/include/engine/BasicPlan.h
+++ b/alica_engine/include/engine/BasicPlan.h
@@ -12,6 +12,8 @@ class Configuration;
 class AlicaEngine;
 class ThreadSafePlanInterface;
 
+// For comments, have a look at BasicBehaviour. This class essentially mimics its behaviour.
+// TODO: This indicates that these classes should probably be combined
 class BasicPlan
 {
 public:
@@ -22,7 +24,6 @@ public:
     void stop();
 
     void setEngine(AlicaEngine* engine) { _ae = engine; }
-    void setRunningPlan(RunningPlan* rp) { _context = rp; }
     void setConfiguration(const Configuration* conf) { _configuration = conf; }
 
     AlicaTime getInterval() { return _msInterval; }
@@ -44,7 +45,6 @@ private:
 
     void sendLogMessage(int level, const std::string& message) const;
 
-    // See BasicBehaviour.h for explanation of the logic used
     static constexpr bool isActive(Counter cnt) { return !(cnt & 1); }
     bool isExecutingInContext() const
     {
@@ -59,8 +59,11 @@ private:
     AlicaTime _msInterval;
     int64_t _activeRunJobId;
 
-    std::atomic<RunningPlan*> _context;
+    std::atomic<RunningPlan*> _signalContext;
+    std::atomic<RunningPlan*> _execContext;
     std::atomic<Counter> _signalState;
     std::atomic<Counter> _execState;
+
+    bool _initExecuted;
 };
 } // namespace alica


### PR DESCRIPTION
The running plan under which the behaviour or plan is executing was not
tracked (execution context). Instead only the running plan under which
the behaviour or plan was started i.e. signal context was tracked. This
meant that it was possible for the behaviour to access a destroyed
running plan object.

Optimization: Skip calling init/terminate when the behaviour/plan's
execution is out of context with the signal from the main thread.

Improve comments