### PR TITLE
fixed test context constructor to use default agentId

### DIFF
--- a/alica_test_utility/include/alica/test/TestContext.h
+++ b/alica_test_utility/include/alica/test/TestContext.h
@@ -24,7 +24,7 @@ class TestContext : public alica::AlicaContext
 public:
     TestContext(const std::string& agentName, const std::string& configPath,
                 const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine,
-                const AgentId agentID);
+                const AgentId agentID = InvalidAgentID);
 
     /**
      * Initialize alica framework and related modules. Note that this


### PR DESCRIPTION
lbc_tests are calling testContext constructor without providing agent id. So I set default agentId to InvalidAgentID