### PR TITLE
Implement hash functions

### DIFF
--- a/alica_engine/include/engine/util/HashFunctions.h
+++ b/alica_engine/include/engine/util/HashFunctions.h
@@ -2,16 +2,42 @@
 #include <stdint.h>
 
 #include "engine/util/cityhash.h"
+#include <functional>
 
 // Thin wrapper over the used hash function:
 namespace alica
 {
 
-// TODO: implement a hash function for integers that avoids collissions
-std::size_t contextHash(int64_t value);
+template <class T>
+struct dependent_false : std::false_type
+{
+};
 
-// TODO: implement a function that can combine 2 hashes
-std::size_t contextHashCombine(std::size_t h1, std::size_t h2);
+template <class T>
+inline void hash_combine(std::size_t& seed, const T& value)
+{
+    // Simple hash_combine, see e.g. here:
+    // https://github.com/HowardHinnant/hash_append/issues/7
+    // Not sure we ever need 32bit, but here it is...
+    if constexpr (sizeof(std::size_t) == 4) {
+        seed ^= std::hash<T>{}(value) + 0x9e3779b9U + (seed << 6) + (seed >> 2);
+    } else if constexpr (sizeof(std::size_t) == 8) {
+        seed ^= std::hash<T>{}(value) + 0x9e3779b97f4a7c15LLU + (seed << 12) + (seed >> 4);
+    } else {
+        static_assert(dependent_false<T>::value, "hash_combine not implemented");
+    }
+}
+
+std::size_t contextHash(int64_t value)
+{
+    return std::hash<int64_t>{}(value);
+}
+
+std::size_t contextHashCombine(std::size_t h1, std::size_t h2)
+{
+    hash_combine(h1, h2);
+    return h1;
+}
 
 inline std::size_t contextHash(std::size_t parentContextHash, int64_t v1, int64_t v2)
 {

--- a/alica_engine/include/engine/util/HashFunctions.h
+++ b/alica_engine/include/engine/util/HashFunctions.h
@@ -30,6 +30,7 @@ inline void hash_combine(std::size_t& seed, const T& value)
 
 std::size_t contextHash(int64_t value)
 {
+    // std::hash is good because in libstdc++ it is implemented using murmurhash2
     return std::hash<int64_t>{}(value);
 }
 


### PR DESCRIPTION
This post contains some info about collisions in murmur2. https://softwareengineering.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed
We use a 64bit hash that should have even less collision than the 32bit version mentioned there.

stdlibc++ uses murmur2
https://github.com/gcc-mirror/gcc/blob/releases/gcc-7/libstdc++-v3/libsupc++/hash_bytes.cc

I copied the boost combine_hash function. I don't see any reason why this would increase the number of collisions, although I couldn't find any evidence for that.
