### PR TITLE
made getTrace public

### DIFF
--- a/alica_engine/include/engine/BasicBehaviour.h
+++ b/alica_engine/include/engine/BasicBehaviour.h
@@ -47,6 +47,7 @@ public:
     using RunnableObject::getWorldModel;
     using RunnableObject::getName;
     using RunnableObject::TracingType;
+    using RunnableObject::getTrace;
 
     virtual void run(void* msg) = 0;
 

--- a/alica_engine/include/engine/BasicBehaviour.h
+++ b/alica_engine/include/engine/BasicBehaviour.h
@@ -47,7 +47,6 @@ public:
     using RunnableObject::getWorldModel;
     using RunnableObject::getName;
     using RunnableObject::TracingType;
-    using RunnableObject::getTrace;
 
     virtual void run(void* msg) = 0;
 
@@ -82,6 +81,8 @@ public:
     bool isEventDriven() const { return _behaviour->isEventDriven(); }
 
 protected:
+    using RunnableObject::getTrace;
+
     AgentId getOwnId() const;
     const AlicaEngine* getEngine() const { return _engine; }
 

--- a/alica_engine/include/engine/BasicPlan.h
+++ b/alica_engine/include/engine/BasicPlan.h
@@ -39,6 +39,8 @@ public:
 
     std::unique_ptr<PlanAttachment>& getPlanAttachment(int64_t id) {return _planAttachments.at(id);}
 protected:
+    using RunnableObject::getTrace;
+    
     void setTracing(TracingType type, std::function<std::optional<std::string>(const BasicPlan*)> customTraceContextGetter = {})
     {
         if (customTraceContextGetter) {


### PR DESCRIPTION
getTrace() is used in lbc at many places that's why it needs to be public otherwise tracing PR build fails