### PR TITLE
Blackboard fix

### DIFF
--- a/alica_engine/include/engine/RunnableObject.h
+++ b/alica_engine/include/engine/RunnableObject.h
@@ -91,7 +91,7 @@ protected:
     std::atomic<RunningPlan*> _signalContext; // The running plan context when start() is called
     std::atomic<RunningPlan*> _execContext;   // The running plan context under which the behaviour is executing
     int64_t _activeRunJobId;
-    std::shared_ptr<Blackboard> _Blackboard;
+    std::shared_ptr<Blackboard> _blackboard;
     IAlicaWorldModel* _wm;
 
     virtual void doInit() = 0;
@@ -115,7 +115,7 @@ protected:
     void initTrace();
     void traceRun();
     void traceInit(const std::string& type);
-    const std::shared_ptr<Blackboard> getBlackboard() { return _Blackboard; }
+    const std::shared_ptr<Blackboard> getBlackboard() { return _blackboard; }
     IAlicaWorldModel* getWorldModel() { return _wm; };
 };
 } /* namespace alica */

--- a/alica_engine/src/engine/RunnableObject.cpp
+++ b/alica_engine/src/engine/RunnableObject.cpp
@@ -64,12 +64,12 @@ void RunnableObject::start(RunningPlan* rp)
 
         BasicPlan* parentPlan = rp->getParent()->getBasicPlan();
         auto& planAttachment = parentPlan->getPlanAttachment(wrapperId);
-        auto initCall = [&, parentPlan=parentPlan]() {
-            if (!_Blackboard) {
-                _Blackboard = std::make_shared<Blackboard>();
+        auto initCall = [&, parentPlan = parentPlan]() {
+            if (!_blackboard) {
+                _blackboard = std::make_shared<Blackboard>();
             }
-            _Blackboard->impl().clear();
-            if (!planAttachment->setParameters(*parentPlan->getBlackboard(), *_Blackboard)) {
+            _blackboard->impl().clear();
+            if (!planAttachment->setParameters(*parentPlan->getBlackboard(), *_blackboard)) {
                 std::cerr << "Setting parameters failed, supposedly as the context has already changed.  Plan will not be scheduled" << std::endl;
                 return;
             }
@@ -82,12 +82,12 @@ void RunnableObject::start(RunningPlan* rp)
         if (rp->getParent() && rp->getParent()->getBasicPlan()) {
             parentPlan = rp->getParent()->getBasicPlan();
         }
-        auto initCall = [this, parentPlan=parentPlan]() {
+        auto initCall = [this, parentPlan = parentPlan]() {
             // Share Blackboard with parent if we have one, or start fresh otherwise
             if (parentPlan) {
-                _Blackboard = parentPlan->getBlackboard();
+                _blackboard = parentPlan->getBlackboard();
             } else {
-                _Blackboard = std::make_shared<Blackboard>();
+                _blackboard = std::make_shared<Blackboard>();
             }
             doInit();
         };

--- a/alica_engine/src/engine/RunnableObject.cpp
+++ b/alica_engine/src/engine/RunnableObject.cpp
@@ -64,7 +64,7 @@ void RunnableObject::start(RunningPlan* rp)
 
         BasicPlan* parentPlan = rp->getParent()->getBasicPlan();
         auto& planAttachment = parentPlan->getPlanAttachment(wrapperId);
-        auto initCall = [&, parentPlan = parentPlan]() {
+        auto initCall = [this, parentPlan = parentPlan]() {
             if (!_blackboard) {
                 _blackboard = std::make_shared<Blackboard>();
             }

--- a/alica_engine/src/engine/RunnableObject.cpp
+++ b/alica_engine/src/engine/RunnableObject.cpp
@@ -78,10 +78,7 @@ void RunnableObject::start(RunningPlan* rp)
         _engine->editScheduler().schedule(initCall);
     } else {
 
-        BasicPlan* parentPlan = nullptr;
-        if (rp->getParent() && rp->getParent()->getBasicPlan()) {
-            parentPlan = rp->getParent()->getBasicPlan();
-        }
+        BasicPlan* parentPlan = rp->getParent() ? rp->getParent()->getBasicPlan() : nullptr;
         auto initCall = [this, parentPlan = parentPlan]() {
             // Share Blackboard with parent if we have one, or start fresh otherwise
             if (parentPlan) {

--- a/alica_engine/src/engine/RunnableObject.cpp
+++ b/alica_engine/src/engine/RunnableObject.cpp
@@ -64,7 +64,7 @@ void RunnableObject::start(RunningPlan* rp)
 
         BasicPlan* parentPlan = rp->getParent()->getBasicPlan();
         auto& planAttachment = parentPlan->getPlanAttachment(wrapperId);
-        auto initCall = [this, parentPlan = parentPlan]() {
+        auto initCall = [this, &planAttachment, parentPlan = parentPlan]() {
             if (!_blackboard) {
                 _blackboard = std::make_shared<Blackboard>();
             }


### PR DESCRIPTION
- parentBlackboard was not properly captured in first lambda (for requiresParameters=true)
- If we have a hierarchy of plans, and all RunnableObject start() methods are called before any init(), then the behavior may not be correct.  We cannot search for the parent plan's blackboard until our own init() timing, since otherwise the parent's blackboard might still be reset to be equal to its parent's blackboard
