### PR TITLE
Map blackboard output after termination

### DIFF
--- a/alica_engine/src/engine/BasicBehaviour.cpp
+++ b/alica_engine/src/engine/BasicBehaviour.cpp
@@ -141,6 +141,14 @@ void BasicBehaviour::doTerminate()
         ALICA_ERROR_MSG("[BasicBehaviour] Exception in Behaviour-TERMINATE of: " << getName() << std::endl << e.what());
     }
 
+    // map output keys to parent blackboard
+    auto rp = _execContext.load();
+    if (rp->getParent() && !getInheritBlackboard()) {
+        auto parentPlan = rp->getParent();
+        auto keyMapping = parentPlan->getKeyMapping(getParentWrapperId(rp));
+        setOutput(parentPlan->getBlackboard().get(), keyMapping);
+    }
+
     // Reset the execution context so that the RunningPlan instance can be deleted
     _execContext.store(nullptr);
 }

--- a/alica_engine/src/engine/BasicPlan.cpp
+++ b/alica_engine/src/engine/BasicPlan.cpp
@@ -78,6 +78,13 @@ void BasicPlan::doTerminate()
         ALICA_ERROR_MSG("[BasicPlan] Exception in Plan-TERMINATE" << std::endl << e.what());
     }
 
+    auto rp = _execContext.load();
+    if (rp->getParent() && !getInheritBlackboard()) {
+        auto parentPlan = rp->getParent();
+        auto keyMapping = parentPlan->getKeyMapping(getParentWrapperId(rp));
+        setOutput(parentPlan->getBlackboard().get(), keyMapping);
+    }
+
     _execContext.store(nullptr);
 }
 

--- a/alica_engine/src/engine/RunnableObject.cpp
+++ b/alica_engine/src/engine/RunnableObject.cpp
@@ -66,19 +66,7 @@ void RunnableObject::stop(RunningPlan* rp)
         return;
     }
     ++_signalState;
-    if (rp->getParent() && !getInheritBlackboard()) {
-
-        auto parentPlan = rp->getParent();
-        auto keyMapping = parentPlan->getKeyMapping(getParentWrapperId(rp));
-        auto terminateCall = [this, parentPlan, keyMapping]() {
-            assert(_blackboard);
-            doTerminate();
-            setOutput(parentPlan->getBlackboard().get(), keyMapping);
-        };
-        _engine->editScheduler().schedule(terminateCall);
-    } else {
-        _engine->editScheduler().schedule([this]() { doTerminate(); });
-    }
+    _engine->editScheduler().schedule([this]() { doTerminate(); });
 }
 
 void RunnableObject::start(RunningPlan* rp)

--- a/alica_engine/src/engine/RunnableObject.cpp
+++ b/alica_engine/src/engine/RunnableObject.cpp
@@ -72,8 +72,8 @@ void RunnableObject::stop(RunningPlan* rp)
         auto keyMapping = parentPlan->getKeyMapping(getParentWrapperId(rp));
         auto terminateCall = [this, parentPlan, keyMapping]() {
             assert(_blackboard);
-            setOutput(parentPlan->getBlackboard().get(), keyMapping);
             doTerminate();
+            setOutput(parentPlan->getBlackboard().get(), keyMapping);
         };
         _engine->editScheduler().schedule(terminateCall);
     } else {


### PR DESCRIPTION
The doTerminate method cancels the run job in the scheduler followed
by calling the termination method of the application. Since the output
key mapping is done before doTerminate without locking the blackboard,
the keys can be mapped at the same time the run & termination methods
access them leading to race conditions. To fix this simply map the keys
after termination but before the running plan goes out of context.