### PR TITLE
change stop method call for BasicPlan when terminated

### DIFF
--- a/alica_engine/src/engine/PlanPool.cpp
+++ b/alica_engine/src/engine/PlanPool.cpp
@@ -129,7 +129,7 @@ void PlanPool::stopPlan(RunningPlan& rp)
 {
     if (const auto* plan = dynamic_cast<const Plan*>(rp.getActivePlan())) {
         if (auto basicPlan = getBasicPlan(plan, rp.getConfiguration())) {
-            basicPlan->stop();
+            basicPlan->stop(&rp);
         }
     } else {
         ALICA_ERROR_MSG("PP::stopPlan(): Cannot stop Plan of given RunningPlan! Plan Name: " << rp.getActivePlan()->getName()


### PR DESCRIPTION
parent blackboard parameters which are mapped to child bb output parameters where not updated when child plan terminates. Please see if this change is valid. 
