### PR TITLE
Allow recursive double locking of fast path events mutex

### DIFF
--- a/alica_engine/include/engine/PlanBase.h
+++ b/alica_engine/include/engine/PlanBase.h
@@ -89,7 +89,7 @@ private:
     AlicaTime _lastSentStatusTime;
     AlicaTime _sendStatusInterval;
 
-    std::mutex _lomutex;
+    std::recursive_mutex _lomutex;
     std::mutex _stepMutex;
 
     std::queue<RunningPlan*> _fpEvents;


### PR DESCRIPTION
While processing fast path events the PlanBase thread can activate
plans & behaviours on a RunningPlan. Activation involves calling init
& run (first call only) which now happen on the same thread. init/run
can set success/failure which adds more fast path events. Therefore
the fast path event mutex can be locked twice. This change converts the
mutex to a recursive mutex to allow for this recursive double locking.