### PR TITLE
Luca refactroy AlicaEngine PR 1

### DIFF
--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -377,13 +377,6 @@ public:
     const YAML::Node& getConfig() const { return _configRootNode; };
 
     /**
-     * Getter/setter for the agents configuration.
-     *
-     * @return YAML::Node& containing the agents configuration.
-     */
-    YAML::Node& editConfig() { return _configRootNode; };
-
-    /**
      * Set config values for the agent.
      *
      * @param path Path of the config value.

--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -377,6 +377,13 @@ public:
     const YAML::Node& getConfig() const { return _configRootNode; };
 
     /**
+     * Getter/setter for the agents configuration.
+     *
+     * @return YAML::Node& containing the agents configuration.
+     */
+    YAML::Node& editConfig() { return _configRootNode; };
+
+    /**
      * Set config values for the agent.
      *
      * @param path Path of the config value.

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -129,7 +129,6 @@ private:
     AlicaContext& _ctx;
     PlanRepository _planRepository;
     ModelManager _modelManager;
-    //std::unique_ptr<ModelManager> _modelManager;
     const Plan* _masterPlan; /**< Pointing to the top level plan of the loaded ALICA program.*/
     const RoleSet* _roleSet; /**< Pointing to the current set of known roles.*/
     TeamManager _teamManager;

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -113,6 +113,7 @@ public:
 
     void reload(const YAML::Node& config);
     const YAML::Node& getConfig() const;
+    YAML::Node& editConfig();
     void subscribe(ReloadFunction reloadFunction);
 
     /**

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -30,9 +30,6 @@ class RoleSet;
 class IRoleAssignment;
 class VariableSyncModule;
 
-using ReloadFunction=std::function<void(const YAML::Node&)>;
-using SubscribeFunction=std::function<void(ReloadFunction)>;
-
 class AlicaEngine
 {
 public:

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -30,6 +30,9 @@ class RoleSet;
 class IRoleAssignment;
 class VariableSyncModule;
 
+using ReloadFunction=std::function<void(const YAML::Node&)>;
+using SubscribeFunction=std::function<void(ReloadFunction)>;
+
 class AlicaEngine
 {
 public:

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -16,7 +16,6 @@
 #include "engine/syncmodule/SyncModule.h"
 #include "engine/teammanager/TeamManager.h"
 
-#include <functional>
 #include <list>
 #include <string>
 #include <unordered_map>
@@ -114,7 +113,7 @@ public:
 
     void reload(const YAML::Node& config);
     const YAML::Node& getConfig() const;
-    void subscribe(std::function<void(const YAML::Node& config)> reloadFunction);
+    void subscribe(ReloadFunction reloadFunction);
 
     /**
      * Call reload() of all subscribed components. Each component does reload using the
@@ -130,6 +129,7 @@ private:
     AlicaContext& _ctx;
     PlanRepository _planRepository;
     ModelManager _modelManager;
+    //std::unique_ptr<ModelManager> _modelManager;
     const Plan* _masterPlan; /**< Pointing to the top level plan of the loaded ALICA program.*/
     const RoleSet* _roleSet; /**< Pointing to the current set of known roles.*/
     TeamManager _teamManager;

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -36,8 +36,8 @@ public:
     template <typename T>
     static void abort(const std::string&, const T& tail);
 
-    AlicaEngine(AlicaContext& ctx, const std::string& configPath, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine,
-            const AgentId agentID = InvalidAgentID);
+    AlicaEngine(AlicaContext& ctx, YAML::Node& config, const std::string& configPath, const std::string& roleSetName, const std::string& masterPlanName,
+            bool stepEngine, const AgentId agentID = InvalidAgentID);
     ~AlicaEngine();
 
     // State modifiers:
@@ -113,7 +113,6 @@ public:
 
     void reload(const YAML::Node& config);
     const YAML::Node& getConfig() const;
-    YAML::Node& editConfig();
     void subscribe(ReloadFunction reloadFunction);
 
     /**

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "engine/AlicaContext.h"
+#include "engine/ConfigChangeListener.h"
 #include "engine/Logger.h"
 #include "engine/PlanBase.h"
 #include "engine/PlanRepository.h"
@@ -113,19 +114,20 @@ public:
 
     void reload(const YAML::Node& config);
     const YAML::Node& getConfig() const;
-    void subscribe(ReloadFunction reloadFunction);
+    void subscribe(ReloadFunction reloadFunction);   // to be removed in the last PR
+    ConfigChangeListener& getConfigChangeListener(); // to be removed in the last PR
 
     /**
      * Call reload() of all subscribed components. Each component does reload using the
      * updated config.
      */
-    void reloadConfig(const YAML::Node& config);
+    void reloadConfig(const YAML::Node& config); // to be removed in the last PR
 
 private:
     void setStepEngine(bool stepEngine);
     // WARNING: Initialization order dependencies!
     // Please do not change the declaration order of members.
-    std::vector<std::function<void(const YAML::Node& config)>> _configChangeListenerCBs;
+    ConfigChangeListener _configChangeListener;
     AlicaContext& _ctx;
     PlanRepository _planRepository;
     ModelManager _modelManager;

--- a/alica_engine/include/engine/ConfigChangeListener.h
+++ b/alica_engine/include/engine/ConfigChangeListener.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <functional>
+#include <vector>
+#include <yaml-cpp/yaml.h>
+
+#include "engine/Types.h"
+
+namespace alica
+{
+
+class ConfigChangeListener
+{
+public:
+    void subscribe(ReloadFunction reloadFunction);
+    void reloadConfig(const YAML::Node& config);
+
+private:
+    std::vector<ReloadFunction> _configChangeListenerCBs;
+};
+
+}

--- a/alica_engine/include/engine/ConfigChangeListener.h
+++ b/alica_engine/include/engine/ConfigChangeListener.h
@@ -18,4 +18,4 @@ public:
 private:
     std::vector<ReloadFunction> _configChangeListenerCBs;
 };
-}
+} // namespace alica

--- a/alica_engine/include/engine/ConfigChangeListener.h
+++ b/alica_engine/include/engine/ConfigChangeListener.h
@@ -18,5 +18,4 @@ public:
 private:
     std::vector<ReloadFunction> _configChangeListenerCBs;
 };
-
 }

--- a/alica_engine/include/engine/GlobalEngineType.h
+++ b/alica_engine/include/engine/GlobalEngineType.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <yaml-cpp/yaml.h>
+#include <functional>
+
+using ReloadFunction = std::function<void(const YAML::Node&)>;
+using SubscribeFunction = std::function<void(ReloadFunction)>;

--- a/alica_engine/include/engine/GlobalEngineType.h
+++ b/alica_engine/include/engine/GlobalEngineType.h
@@ -1,7 +1,0 @@
-#pragma once
-
-#include <yaml-cpp/yaml.h>
-#include <functional>
-
-using ReloadFunction = std::function<void(const YAML::Node&)>;
-using SubscribeFunction = std::function<void(ReloadFunction)>;

--- a/alica_engine/include/engine/Types.h
+++ b/alica_engine/include/engine/Types.h
@@ -58,7 +58,7 @@ using ParameterMap = std::unordered_map<std::string, Parameter*>;
 using AgentStatePair = std::pair<AgentId, const State*>;
 
 using ReloadFunction = std::function<void(const YAML::Node&)>;
-using SubscribeFunction = std::function<void(ReloadFunction)>;
+using ConfigChangeSubscriber = std::function<void(ReloadFunction)>;
 
 constexpr auto InvalidAgentID = std::numeric_limits<uint64_t>::max();
 

--- a/alica_engine/include/engine/Types.h
+++ b/alica_engine/include/engine/Types.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <functional>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 #include <yaml-cpp/yaml.h>
-#include <functional>
 
 namespace alica
 {

--- a/alica_engine/include/engine/Types.h
+++ b/alica_engine/include/engine/Types.h
@@ -4,6 +4,8 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <yaml-cpp/yaml.h>
+#include <functional>
 
 namespace alica
 {
@@ -54,6 +56,9 @@ using VariableGrp = std::vector<const Variable*>;
 
 using ParameterMap = std::unordered_map<std::string, Parameter*>;
 using AgentStatePair = std::pair<AgentId, const State*>;
+
+using ReloadFunction = std::function<void(const YAML::Node&)>;
+using SubscribeFunction = std::function<void(ReloadFunction)>;
 
 constexpr auto InvalidAgentID = std::numeric_limits<uint64_t>::max();
 

--- a/alica_engine/include/engine/model/AbstractPlan.h
+++ b/alica_engine/include/engine/model/AbstractPlan.h
@@ -25,10 +25,10 @@ class AlicaEngine;
 class AbstractPlan : public AlicaElement
 {
 public:
-    //[[deprecated("It will be removed in the last PR")]] 
-    AbstractPlan(AlicaEngine* ae);//TOBE removed
-    //[[deprecated("It will be removed in the last PR")]] 
-    AbstractPlan(AlicaEngine* ae, int64_t id);//TOBE removed
+    //[[deprecated("It will be removed in the last PR")]]
+    AbstractPlan(AlicaEngine* ae); // TOBE removed
+    //[[deprecated("It will be removed in the last PR")]]
+    AbstractPlan(AlicaEngine* ae, int64_t id); // TOBE removed
     AbstractPlan(const YAML::Node& config, SubscribeFunction subscribeFunc);
     AbstractPlan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id);
 

--- a/alica_engine/include/engine/model/AbstractPlan.h
+++ b/alica_engine/include/engine/model/AbstractPlan.h
@@ -29,8 +29,8 @@ public:
     AbstractPlan(AlicaEngine* ae); // TOBE removed
     //[[deprecated("It will be removed in the last PR")]]
     AbstractPlan(AlicaEngine* ae, int64_t id); // TOBE removed
-    AbstractPlan(const YAML::Node& config, SubscribeFunction subscribeFunc);
-    AbstractPlan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id);
+    AbstractPlan(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc);
+    AbstractPlan(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, int64_t id);
 
     virtual ~AbstractPlan();
 

--- a/alica_engine/include/engine/model/AbstractPlan.h
+++ b/alica_engine/include/engine/model/AbstractPlan.h
@@ -29,7 +29,7 @@ public:
     AbstractPlan(AlicaEngine* ae); // TOBE removed
     //[[deprecated("It will be removed in the last PR")]]
     AbstractPlan(AlicaEngine* ae, int64_t id); // TOBE removed
-    AbstractPlan(const YAML::Node& config );
+    AbstractPlan(const YAML::Node& config);
     AbstractPlan(const YAML::Node& config, int64_t id);
 
     virtual ~AbstractPlan();
@@ -37,11 +37,10 @@ public:
     bool containsVar(const Variable* v) const;
     bool containsVar(const std::string& name) const;
     const VariableGrp& getVariables() const { return _variables; }
-    const Variable* getVariable(const std::string& name) const;  
+    const Variable* getVariable(const std::string& name) const;
 
     std::string toString(std::string indent = "") const override;
     const std::string& getFileName() const { return _fileName; }
-
 
 private:
     friend ModelFactory;

--- a/alica_engine/include/engine/model/AbstractPlan.h
+++ b/alica_engine/include/engine/model/AbstractPlan.h
@@ -29,23 +29,19 @@ public:
     AbstractPlan(AlicaEngine* ae); // TOBE removed
     //[[deprecated("It will be removed in the last PR")]]
     AbstractPlan(AlicaEngine* ae, int64_t id); // TOBE removed
-    AbstractPlan(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc);
-    AbstractPlan(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, int64_t id);
+    AbstractPlan(const YAML::Node& config );
+    AbstractPlan(const YAML::Node& config, int64_t id);
 
     virtual ~AbstractPlan();
 
     bool containsVar(const Variable* v) const;
     bool containsVar(const std::string& name) const;
     const VariableGrp& getVariables() const { return _variables; }
-    const Variable* getVariable(const std::string& name) const;
-
-    AlicaTime getAuthorityTimeInterval() const { return _authorityTimeInterval; }
-    void setAuthorityTimeInterval(AlicaTime authorityTimeInterval) const; // not a mistake, this is mutable
+    const Variable* getVariable(const std::string& name) const;  
 
     std::string toString(std::string indent = "") const override;
     const std::string& getFileName() const { return _fileName; }
 
-    void reload(const YAML::Node& config);
 
 private:
     friend ModelFactory;
@@ -63,9 +59,6 @@ private:
      * The file this abstract plan is parsed from/ written to.
      */
     std::string _fileName;
-
-    // TODO: move this to the authority module
-    mutable AlicaTime _authorityTimeInterval;
 };
 
 } // namespace alica

--- a/alica_engine/include/engine/model/AbstractPlan.h
+++ b/alica_engine/include/engine/model/AbstractPlan.h
@@ -25,8 +25,10 @@ class AlicaEngine;
 class AbstractPlan : public AlicaElement
 {
 public:
-    [[deprecated("It will be removed in the last PR")]] AbstractPlan(AlicaEngine* ae);
-    [[deprecated("It will be removed in the last PR")]] AbstractPlan(AlicaEngine* ae, int64_t id);
+    //[[deprecated("It will be removed in the last PR")]] 
+    AbstractPlan(AlicaEngine* ae);//TOBE removed
+    //[[deprecated("It will be removed in the last PR")]] 
+    AbstractPlan(AlicaEngine* ae, int64_t id);//TOBE removed
     AbstractPlan(const YAML::Node& config, SubscribeFunction subscribeFunc);
     AbstractPlan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id);
 

--- a/alica_engine/include/engine/model/AbstractPlan.h
+++ b/alica_engine/include/engine/model/AbstractPlan.h
@@ -25,8 +25,10 @@ class AlicaEngine;
 class AbstractPlan : public AlicaElement
 {
 public:
-    AbstractPlan(AlicaEngine* ae);
-    AbstractPlan(AlicaEngine* ae, int64_t id);
+    [[deprecated("It will be removed in the last PR")]] AbstractPlan(AlicaEngine* ae);
+    [[deprecated("It will be removed in the last PR")]] AbstractPlan(AlicaEngine* ae, int64_t id);
+    AbstractPlan(const YAML::Node& config, SubscribeFunction subscribeFunc);
+    AbstractPlan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id);
 
     virtual ~AbstractPlan();
 

--- a/alica_engine/include/engine/model/Behaviour.h
+++ b/alica_engine/include/engine/model/Behaviour.h
@@ -28,7 +28,8 @@ class AlicaEngine;
 class Behaviour : public AbstractPlan
 {
 public:
-    Behaviour(AlicaEngine* ae);
+    [[deprecated("It will be removed in the last PR")]] Behaviour(AlicaEngine* ae);
+    Behaviour(const YAML::Node& config, SubscribeFunction subscribeFunc);
     virtual ~Behaviour();
 
     std::string toString(std::string indent = "") const;

--- a/alica_engine/include/engine/model/Behaviour.h
+++ b/alica_engine/include/engine/model/Behaviour.h
@@ -29,7 +29,7 @@ class Behaviour : public AbstractPlan
 {
 public:
     //[[deprecated("It will be removed in the last PR")]]
-    Behaviour(AlicaEngine* ae);//TOBE removed
+    Behaviour(AlicaEngine* ae); // TOBE removed
     Behaviour(const YAML::Node& config, SubscribeFunction subscribeFunc);
     virtual ~Behaviour();
 

--- a/alica_engine/include/engine/model/Behaviour.h
+++ b/alica_engine/include/engine/model/Behaviour.h
@@ -28,7 +28,8 @@ class AlicaEngine;
 class Behaviour : public AbstractPlan
 {
 public:
-    [[deprecated("It will be removed in the last PR")]] Behaviour(AlicaEngine* ae);
+    //[[deprecated("It will be removed in the last PR")]]
+    Behaviour(AlicaEngine* ae);//TOBE removed
     Behaviour(const YAML::Node& config, SubscribeFunction subscribeFunc);
     virtual ~Behaviour();
 

--- a/alica_engine/include/engine/model/Behaviour.h
+++ b/alica_engine/include/engine/model/Behaviour.h
@@ -30,7 +30,7 @@ class Behaviour : public AbstractPlan
 public:
     //[[deprecated("It will be removed in the last PR")]]
     Behaviour(AlicaEngine* ae); // TOBE removed
-    Behaviour(const YAML::Node& config, SubscribeFunction subscribeFunc);
+    Behaviour(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc);
     virtual ~Behaviour();
 
     std::string toString(std::string indent = "") const;

--- a/alica_engine/include/engine/model/Behaviour.h
+++ b/alica_engine/include/engine/model/Behaviour.h
@@ -30,7 +30,7 @@ class Behaviour : public AbstractPlan
 public:
     //[[deprecated("It will be removed in the last PR")]]
     Behaviour(AlicaEngine* ae); // TOBE removed
-    Behaviour(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc);
+    Behaviour(const YAML::Node& config);
     virtual ~Behaviour();
 
     std::string toString(std::string indent = "") const;

--- a/alica_engine/include/engine/model/Plan.h
+++ b/alica_engine/include/engine/model/Plan.h
@@ -25,7 +25,8 @@ class BlackboardBlueprint;
 class Plan : public AbstractPlan
 {
 public:
-    Plan(AlicaEngine* ae, int64_t id);
+    [[deprecated("It will be removed in the last PR")]] Plan(AlicaEngine* ae, int64_t id);
+    Plan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id);
     virtual ~Plan();
 
     const EntryPoint* getEntryPointTaskID(int64_t taskID) const;

--- a/alica_engine/include/engine/model/Plan.h
+++ b/alica_engine/include/engine/model/Plan.h
@@ -19,6 +19,7 @@ class PreCondition;
 class RuntimeCondition;
 class AlicaEngine;
 class BlackboardBlueprint;
+class ConfigChangeListener;
 /**
  * An ALICA plan
  */
@@ -27,7 +28,7 @@ class Plan : public AbstractPlan
 public:
     //[[deprecated("It will be removed in the last PR")]]
     Plan(AlicaEngine* ae, int64_t id); // TOBE removed
-    Plan(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, int64_t id);
+    Plan(const YAML::Node& config, ConfigChangeListener& configChangeListener, int64_t id);
     virtual ~Plan();
 
     const EntryPoint* getEntryPointTaskID(int64_t taskID) const;
@@ -57,6 +58,11 @@ public:
     const BlackboardBlueprint* getBlackboardBlueprint() const { return _blackboardBlueprint.get(); }
 
     std::string toString(std::string indent = "") const;
+
+    AlicaTime getAuthorityTimeInterval() const { return _authorityTimeInterval; }
+    void setAuthorityTimeInterval(AlicaTime authorityTimeInterval) const; // not a mistake, this is mutable
+
+    void reload(const YAML::Node& config);
 
 private:
     friend ModelFactory;
@@ -114,6 +120,9 @@ private:
      * Otherwise, the mapped keys will be copied in and out of the plans Blackboard
      */
     std::unique_ptr<BlackboardBlueprint> _blackboardBlueprint;
+
+    // TODO: move this to the authority module
+    mutable AlicaTime _authorityTimeInterval;
 };
 
 } // namespace alica

--- a/alica_engine/include/engine/model/Plan.h
+++ b/alica_engine/include/engine/model/Plan.h
@@ -27,7 +27,7 @@ class Plan : public AbstractPlan
 public:
     //[[deprecated("It will be removed in the last PR")]]
     Plan(AlicaEngine* ae, int64_t id); // TOBE removed
-    Plan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id);
+    Plan(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, int64_t id);
     virtual ~Plan();
 
     const EntryPoint* getEntryPointTaskID(int64_t taskID) const;

--- a/alica_engine/include/engine/model/Plan.h
+++ b/alica_engine/include/engine/model/Plan.h
@@ -25,8 +25,8 @@ class BlackboardBlueprint;
 class Plan : public AbstractPlan
 {
 public:
-    //[[deprecated("It will be removed in the last PR")]] 
-    Plan(AlicaEngine* ae, int64_t id);//TOBE removed
+    //[[deprecated("It will be removed in the last PR")]]
+    Plan(AlicaEngine* ae, int64_t id); // TOBE removed
     Plan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id);
     virtual ~Plan();
 

--- a/alica_engine/include/engine/model/Plan.h
+++ b/alica_engine/include/engine/model/Plan.h
@@ -25,7 +25,8 @@ class BlackboardBlueprint;
 class Plan : public AbstractPlan
 {
 public:
-    [[deprecated("It will be removed in the last PR")]] Plan(AlicaEngine* ae, int64_t id);
+    //[[deprecated("It will be removed in the last PR")]] 
+    Plan(AlicaEngine* ae, int64_t id);//TOBE removed
     Plan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id);
     virtual ~Plan();
 

--- a/alica_engine/include/engine/model/PlanType.h
+++ b/alica_engine/include/engine/model/PlanType.h
@@ -18,7 +18,8 @@ class AlicaEngine;
 class PlanType : public AbstractPlan
 {
 public:
-    [[deprecated("It will be removed in the last PR")]] PlanType(AlicaEngine* ae);
+    //[[deprecated("It will be removed in the last PR")]]
+    PlanType(AlicaEngine* ae);//TOBE removed
     PlanType(const YAML::Node& config, SubscribeFunction subscribeFunc);
     virtual ~PlanType();
 

--- a/alica_engine/include/engine/model/PlanType.h
+++ b/alica_engine/include/engine/model/PlanType.h
@@ -20,7 +20,7 @@ class PlanType : public AbstractPlan
 public:
     //[[deprecated("It will be removed in the last PR")]]
     PlanType(AlicaEngine* ae); // TOBE removed
-    PlanType(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc);
+    PlanType(const YAML::Node& config);
     virtual ~PlanType();
 
     std::string toString(std::string indent = "") const override;

--- a/alica_engine/include/engine/model/PlanType.h
+++ b/alica_engine/include/engine/model/PlanType.h
@@ -20,7 +20,7 @@ class PlanType : public AbstractPlan
 public:
     //[[deprecated("It will be removed in the last PR")]]
     PlanType(AlicaEngine* ae); // TOBE removed
-    PlanType(const YAML::Node& config, SubscribeFunction subscribeFunc);
+    PlanType(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc);
     virtual ~PlanType();
 
     std::string toString(std::string indent = "") const override;

--- a/alica_engine/include/engine/model/PlanType.h
+++ b/alica_engine/include/engine/model/PlanType.h
@@ -19,7 +19,7 @@ class PlanType : public AbstractPlan
 {
 public:
     //[[deprecated("It will be removed in the last PR")]]
-    PlanType(AlicaEngine* ae);//TOBE removed
+    PlanType(AlicaEngine* ae); // TOBE removed
     PlanType(const YAML::Node& config, SubscribeFunction subscribeFunc);
     virtual ~PlanType();
 

--- a/alica_engine/include/engine/model/PlanType.h
+++ b/alica_engine/include/engine/model/PlanType.h
@@ -18,7 +18,8 @@ class AlicaEngine;
 class PlanType : public AbstractPlan
 {
 public:
-    PlanType(AlicaEngine* ae);
+    [[deprecated("It will be removed in the last PR")]] PlanType(AlicaEngine* ae);
+    PlanType(const YAML::Node& config, SubscribeFunction subscribeFunc);
     virtual ~PlanType();
 
     std::string toString(std::string indent = "") const override;

--- a/alica_engine/include/engine/modelmanagement/ModelManager.h
+++ b/alica_engine/include/engine/modelmanagement/ModelManager.h
@@ -21,6 +21,7 @@ class Plan;
 class RoleSet;
 class Factory;
 class AlicaEngine;
+class ConfigChangeListener;
 
 /**
  * Parse the plan tree from disk and writes it back. Fills the PlanRepository and holds all existing elements.
@@ -30,7 +31,7 @@ class ModelManager
 public:
     //[[deprecated("It will be removed in the last PR")]]
     ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder); // TOBE removed
-    ModelManager(PlanRepository& planRepository, YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const std::string& domainConfigFolder);
+    ModelManager(PlanRepository& planRepository, YAML::Node& config, ConfigChangeListener& configChangeListener, const std::string& domainConfigFolder);
     Plan* loadPlanTree(const std::string& masterPlanName);
     RoleSet* loadRoleSet(const std::string& roleSetName);
 
@@ -42,7 +43,7 @@ private:
     friend Factory;
 
     YAML::Node& _config;
-    ConfigChangeSubscriber _subscribeFunc;
+    ConfigChangeListener& _configChangeListener;
     std::string domainConfigFolder;
     std::string basePlanPath;
     std::string baseRolePath;

--- a/alica_engine/include/engine/modelmanagement/ModelManager.h
+++ b/alica_engine/include/engine/modelmanagement/ModelManager.h
@@ -28,7 +28,8 @@ class AlicaEngine;
 class ModelManager
 {
 public:
-    [[deprecated("It will be removed in the last PR")]] ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder);
+    //[[deprecated("It will be removed in the last PR")]] 
+    ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder);//TOBE removed
     ModelManager(PlanRepository& planRepository, const YAML::Node& config, SubscribeFunction subscribeFunc, const std::string& domainConfigFolder);
     Plan* loadPlanTree(const std::string& masterPlanName);
     RoleSet* loadRoleSet(const std::string& roleSetName);

--- a/alica_engine/include/engine/modelmanagement/ModelManager.h
+++ b/alica_engine/include/engine/modelmanagement/ModelManager.h
@@ -30,7 +30,7 @@ class ModelManager
 public:
     //[[deprecated("It will be removed in the last PR")]]
     ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder); // TOBE removed
-    ModelManager(PlanRepository& planRepository, const YAML::Node& config, SubscribeFunction subscribeFunc, const std::string& domainConfigFolder);
+    ModelManager(PlanRepository& planRepository, YAML::Node& config, SubscribeFunction subscribeFunc, const std::string& domainConfigFolder);
     Plan* loadPlanTree(const std::string& masterPlanName);
     RoleSet* loadRoleSet(const std::string& roleSetName);
 
@@ -41,7 +41,7 @@ public:
 private:
     friend Factory;
 
-    const YAML::Node& _config;
+    YAML::Node& _config;
     SubscribeFunction _subscribeFunc;
     std::string domainConfigFolder;
     std::string basePlanPath;

--- a/alica_engine/include/engine/modelmanagement/ModelManager.h
+++ b/alica_engine/include/engine/modelmanagement/ModelManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../GlobalEngineType.h"
+#include "engine/Types.h"
 #include <yaml-cpp/yaml.h>
 
 #include <functional>
@@ -29,7 +29,7 @@ class ModelManager
 {
 public:
     [[deprecated("It will be removed in the last PR")]] ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder);
-    ModelManager(PlanRepository& planRepository, const YAML::Node& config, SubscribeFunction subscribe, const std::string& domainConfigFolder);
+    ModelManager(PlanRepository& planRepository, const YAML::Node& config, SubscribeFunction subscribeFunc, const std::string& domainConfigFolder);
     Plan* loadPlanTree(const std::string& masterPlanName);
     RoleSet* loadRoleSet(const std::string& roleSetName);
 
@@ -42,6 +42,7 @@ private:
 
     AlicaEngine* _ae;
     const YAML::Node& _config;
+    SubscribeFunction _subscribeFunc;
     std::string domainConfigFolder;
     std::string basePlanPath;
     std::string baseRolePath;

--- a/alica_engine/include/engine/modelmanagement/ModelManager.h
+++ b/alica_engine/include/engine/modelmanagement/ModelManager.h
@@ -30,7 +30,7 @@ class ModelManager
 public:
     //[[deprecated("It will be removed in the last PR")]]
     ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder); // TOBE removed
-    ModelManager(PlanRepository& planRepository, YAML::Node& config, SubscribeFunction subscribeFunc, const std::string& domainConfigFolder);
+    ModelManager(PlanRepository& planRepository, YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const std::string& domainConfigFolder);
     Plan* loadPlanTree(const std::string& masterPlanName);
     RoleSet* loadRoleSet(const std::string& roleSetName);
 
@@ -42,7 +42,7 @@ private:
     friend Factory;
 
     YAML::Node& _config;
-    SubscribeFunction _subscribeFunc;
+    ConfigChangeSubscriber _subscribeFunc;
     std::string domainConfigFolder;
     std::string basePlanPath;
     std::string baseRolePath;

--- a/alica_engine/include/engine/modelmanagement/ModelManager.h
+++ b/alica_engine/include/engine/modelmanagement/ModelManager.h
@@ -28,8 +28,8 @@ class AlicaEngine;
 class ModelManager
 {
 public:
-    //[[deprecated("It will be removed in the last PR")]] 
-    ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder);//TOBE removed
+    //[[deprecated("It will be removed in the last PR")]]
+    ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder); // TOBE removed
     ModelManager(PlanRepository& planRepository, const YAML::Node& config, SubscribeFunction subscribeFunc, const std::string& domainConfigFolder);
     Plan* loadPlanTree(const std::string& masterPlanName);
     RoleSet* loadRoleSet(const std::string& roleSetName);

--- a/alica_engine/include/engine/modelmanagement/ModelManager.h
+++ b/alica_engine/include/engine/modelmanagement/ModelManager.h
@@ -40,7 +40,6 @@ public:
 private:
     friend Factory;
 
-    AlicaEngine* _ae;
     const YAML::Node& _config;
     SubscribeFunction _subscribeFunc;
     std::string domainConfigFolder;

--- a/alica_engine/include/engine/modelmanagement/ModelManager.h
+++ b/alica_engine/include/engine/modelmanagement/ModelManager.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "../GlobalEngineType.h"
 #include <yaml-cpp/yaml.h>
 
+#include <functional>
 #include <string>
 
 namespace essentials
@@ -26,7 +28,8 @@ class AlicaEngine;
 class ModelManager
 {
 public:
-    ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder);
+    [[deprecated("It will be removed in the last PR")]] ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder);
+    ModelManager(PlanRepository& planRepository, const YAML::Node& config, SubscribeFunction subscribe, const std::string& domainConfigFolder);
     Plan* loadPlanTree(const std::string& masterPlanName);
     RoleSet* loadRoleSet(const std::string& roleSetName);
 
@@ -38,6 +41,7 @@ private:
     friend Factory;
 
     AlicaEngine* _ae;
+    const YAML::Node& _config;
     std::string domainConfigFolder;
     std::string basePlanPath;
     std::string baseRolePath;

--- a/alica_engine/include/engine/modelmanagement/factories/BehaviourFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/BehaviourFactory.h
@@ -10,7 +10,9 @@ class Behaviour;
 class BehaviourFactory : public Factory
 {
 public:
-    static Behaviour* create(AlicaEngine* ae, const YAML::Node& node);
+    [[deprecated("It will be removed in the last PR")]] static Behaviour* create(AlicaEngine* ae, const YAML::Node& node);
+    static Behaviour* create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node);
+
     static void attachReferences();
 
 private:

--- a/alica_engine/include/engine/modelmanagement/factories/BehaviourFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/BehaviourFactory.h
@@ -10,8 +10,8 @@ class Behaviour;
 class BehaviourFactory : public Factory
 {
 public:
-    //[[deprecated("It will be removed in the last PR")]] 
-    static Behaviour* create(AlicaEngine* ae, const YAML::Node& node);//TOBE removed
+    //[[deprecated("It will be removed in the last PR")]]
+    static Behaviour* create(AlicaEngine* ae, const YAML::Node& node); // TOBE removed
     static Behaviour* create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node);
 
     static void attachReferences();

--- a/alica_engine/include/engine/modelmanagement/factories/BehaviourFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/BehaviourFactory.h
@@ -12,7 +12,7 @@ class BehaviourFactory : public Factory
 public:
     //[[deprecated("It will be removed in the last PR")]]
     static Behaviour* create(AlicaEngine* ae, const YAML::Node& node); // TOBE removed
-    static Behaviour* create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node);
+    static Behaviour* create(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const YAML::Node& node);
 
     static void attachReferences();
 

--- a/alica_engine/include/engine/modelmanagement/factories/BehaviourFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/BehaviourFactory.h
@@ -12,7 +12,7 @@ class BehaviourFactory : public Factory
 public:
     //[[deprecated("It will be removed in the last PR")]]
     static Behaviour* create(AlicaEngine* ae, const YAML::Node& node); // TOBE removed
-    static Behaviour* create(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const YAML::Node& node);
+    static Behaviour* create(const YAML::Node& config,  const YAML::Node& node);
 
     static void attachReferences();
 

--- a/alica_engine/include/engine/modelmanagement/factories/BehaviourFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/BehaviourFactory.h
@@ -10,7 +10,8 @@ class Behaviour;
 class BehaviourFactory : public Factory
 {
 public:
-    [[deprecated("It will be removed in the last PR")]] static Behaviour* create(AlicaEngine* ae, const YAML::Node& node);
+    //[[deprecated("It will be removed in the last PR")]] 
+    static Behaviour* create(AlicaEngine* ae, const YAML::Node& node);//TOBE removed
     static Behaviour* create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node);
 
     static void attachReferences();

--- a/alica_engine/include/engine/modelmanagement/factories/BehaviourFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/BehaviourFactory.h
@@ -12,7 +12,7 @@ class BehaviourFactory : public Factory
 public:
     //[[deprecated("It will be removed in the last PR")]]
     static Behaviour* create(AlicaEngine* ae, const YAML::Node& node); // TOBE removed
-    static Behaviour* create(const YAML::Node& config,  const YAML::Node& node);
+    static Behaviour* create(const YAML::Node& config, const YAML::Node& node);
 
     static void attachReferences();
 

--- a/alica_engine/include/engine/modelmanagement/factories/PlanFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/PlanFactory.h
@@ -11,8 +11,8 @@ class Plan;
 class PlanFactory : public Factory
 {
 public:
-    //[[deprecated("It will be removed in the last PR")]] 
-    static Plan* create(AlicaEngine* ae, const YAML::Node& node);//TOBE removed
+    //[[deprecated("It will be removed in the last PR")]]
+    static Plan* create(AlicaEngine* ae, const YAML::Node& node); // TOBE removed
     static Plan* create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node);
     static void attachReferences();
 

--- a/alica_engine/include/engine/modelmanagement/factories/PlanFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/PlanFactory.h
@@ -11,7 +11,8 @@ class Plan;
 class PlanFactory : public Factory
 {
 public:
-    [[deprecated("It will be removed in the last PR")]] static Plan* create(AlicaEngine* ae, const YAML::Node& node);
+    //[[deprecated("It will be removed in the last PR")]] 
+    static Plan* create(AlicaEngine* ae, const YAML::Node& node);//TOBE removed
     static Plan* create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node);
     static void attachReferences();
 

--- a/alica_engine/include/engine/modelmanagement/factories/PlanFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/PlanFactory.h
@@ -13,7 +13,7 @@ class PlanFactory : public Factory
 public:
     //[[deprecated("It will be removed in the last PR")]]
     static Plan* create(AlicaEngine* ae, const YAML::Node& node); // TOBE removed
-    static Plan* create(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const YAML::Node& node);
+    static Plan* create(const YAML::Node& config, ConfigChangeListener& configChangeListener, const YAML::Node& node);
     static void attachReferences();
 
 private:

--- a/alica_engine/include/engine/modelmanagement/factories/PlanFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/PlanFactory.h
@@ -10,7 +10,8 @@ class Plan;
 class PlanFactory : public Factory
 {
 public:
-    static Plan* create(AlicaEngine* ae, const YAML::Node& node);
+    [[deprecated("It will be removed in the last PR")]] static Plan* create(AlicaEngine* ae, const YAML::Node& node);
+    static Plan* create(const YAML::Node& config, SubscribeFunction subscribe, const YAML::Node& node);
     static void attachReferences();
 
 private:

--- a/alica_engine/include/engine/modelmanagement/factories/PlanFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/PlanFactory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Factory.h"
+#include "engine/Types.h"
 
 #include <yaml-cpp/yaml.h>
 
@@ -11,7 +12,7 @@ class PlanFactory : public Factory
 {
 public:
     [[deprecated("It will be removed in the last PR")]] static Plan* create(AlicaEngine* ae, const YAML::Node& node);
-    static Plan* create(const YAML::Node& config, SubscribeFunction subscribe, const YAML::Node& node);
+    static Plan* create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node);
     static void attachReferences();
 
 private:

--- a/alica_engine/include/engine/modelmanagement/factories/PlanFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/PlanFactory.h
@@ -13,7 +13,7 @@ class PlanFactory : public Factory
 public:
     //[[deprecated("It will be removed in the last PR")]]
     static Plan* create(AlicaEngine* ae, const YAML::Node& node); // TOBE removed
-    static Plan* create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node);
+    static Plan* create(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const YAML::Node& node);
     static void attachReferences();
 
 private:

--- a/alica_engine/include/engine/modelmanagement/factories/PlanTypeFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/PlanTypeFactory.h
@@ -12,7 +12,7 @@ class PlanTypeFactory : public Factory
 public:
     //[[deprecated("It will be removed in the last PR")]]
     static PlanType* create(AlicaEngine* ae, const YAML::Node& planTypeNode); // TOBE removed
-    static PlanType* create(const YAML::Node& config,  const YAML::Node& planTypeNode);
+    static PlanType* create(const YAML::Node& config, const YAML::Node& planTypeNode);
     static void attachReferences();
 
 private:

--- a/alica_engine/include/engine/modelmanagement/factories/PlanTypeFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/PlanTypeFactory.h
@@ -12,7 +12,7 @@ class PlanTypeFactory : public Factory
 public:
     //[[deprecated("It will be removed in the last PR")]]
     static PlanType* create(AlicaEngine* ae, const YAML::Node& planTypeNode); // TOBE removed
-    static PlanType* create(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const YAML::Node& planTypeNode);
+    static PlanType* create(const YAML::Node& config,  const YAML::Node& planTypeNode);
     static void attachReferences();
 
 private:

--- a/alica_engine/include/engine/modelmanagement/factories/PlanTypeFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/PlanTypeFactory.h
@@ -10,7 +10,8 @@ class PlanType;
 class PlanTypeFactory : public Factory
 {
 public:
-    [[deprecated("It will be removed in the last PR")]] static PlanType* create(AlicaEngine* ae, const YAML::Node& planTypeNode);
+    //[[deprecated("It will be removed in the last PR")]] 
+    static PlanType* create(AlicaEngine* ae, const YAML::Node& planTypeNode);//TOBE removed
     static PlanType* create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& planTypeNode);
     static void attachReferences();
 

--- a/alica_engine/include/engine/modelmanagement/factories/PlanTypeFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/PlanTypeFactory.h
@@ -10,7 +10,8 @@ class PlanType;
 class PlanTypeFactory : public Factory
 {
 public:
-    static PlanType* create(AlicaEngine* ae, const YAML::Node& planTypeNode);
+    [[deprecated("It will be removed in the last PR")]] static PlanType* create(AlicaEngine* ae, const YAML::Node& planTypeNode);
+    static PlanType* create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& planTypeNode);
     static void attachReferences();
 
 private:

--- a/alica_engine/include/engine/modelmanagement/factories/PlanTypeFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/PlanTypeFactory.h
@@ -10,8 +10,8 @@ class PlanType;
 class PlanTypeFactory : public Factory
 {
 public:
-    //[[deprecated("It will be removed in the last PR")]] 
-    static PlanType* create(AlicaEngine* ae, const YAML::Node& planTypeNode);//TOBE removed
+    //[[deprecated("It will be removed in the last PR")]]
+    static PlanType* create(AlicaEngine* ae, const YAML::Node& planTypeNode); // TOBE removed
     static PlanType* create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& planTypeNode);
     static void attachReferences();
 

--- a/alica_engine/include/engine/modelmanagement/factories/PlanTypeFactory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/PlanTypeFactory.h
@@ -12,7 +12,7 @@ class PlanTypeFactory : public Factory
 public:
     //[[deprecated("It will be removed in the last PR")]]
     static PlanType* create(AlicaEngine* ae, const YAML::Node& planTypeNode); // TOBE removed
-    static PlanType* create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& planTypeNode);
+    static PlanType* create(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const YAML::Node& planTypeNode);
     static void attachReferences();
 
 private:

--- a/alica_engine/src/engine/AlicaContext.cpp
+++ b/alica_engine/src/engine/AlicaContext.cpp
@@ -19,8 +19,8 @@ constexpr int ALICA_LOOP_TIME_ESTIMATE = 33; // ms
 AlicaContext::AlicaContext(const AlicaContextParams& alicaContextParams)
         : _validTag(ALICA_CTX_GOOD)
         , _configRootNode(initConfig(alicaContextParams.configPath, alicaContextParams.agentName))
-        , _engine(std::make_unique<AlicaEngine>(*this, alicaContextParams.configPath, alicaContextParams.roleSetName, alicaContextParams.masterPlanName,
-                  alicaContextParams.stepEngine, alicaContextParams.agentID))
+        , _engine(std::make_unique<AlicaEngine>(*this, _configRootNode, alicaContextParams.configPath, alicaContextParams.roleSetName,
+                  alicaContextParams.masterPlanName, alicaContextParams.stepEngine, alicaContextParams.agentID))
         , _clock(std::make_unique<AlicaClock>())
         , _communicator(nullptr)
         , _worldModel(nullptr)

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -41,7 +41,7 @@ AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& configPath, const
         , _stepCalled(false)
         , _stepEngine(stepEngine)
         , _log(this)
-        , _modelManager(_planRepository, _ctx.getConfig(),std::bind(&AlicaEngine::subscribe, this, std::placeholders::_1), configPath)
+        , _modelManager(_planRepository, _ctx.getConfig(), std::bind(&AlicaEngine::subscribe, this, std::placeholders::_1), configPath)
         , _masterPlan(_modelManager.loadPlanTree(masterPlanName))
         , _roleSet(_modelManager.loadRoleSet(roleSetName))
         , _teamManager(this, agentID)

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -35,13 +35,13 @@ void AlicaEngine::abort(const std::string& msg)
 /**
  * The main class.
  */
-AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& configPath, const std::string& roleSetName, const std::string& masterPlanName, bool stepEngine,
-        const AgentId agentID)
+AlicaEngine::AlicaEngine(AlicaContext& ctx, YAML::Node& config, const std::string& configPath, const std::string& roleSetName,
+        const std::string& masterPlanName, bool stepEngine, const AgentId agentID)
         : _ctx(ctx)
         , _stepCalled(false)
         , _stepEngine(stepEngine)
         , _log(this)
-        , _modelManager(_planRepository, _ctx.editConfig(), std::bind(&AlicaEngine::subscribe, this, std::placeholders::_1), configPath)
+        , _modelManager(_planRepository, config, std::bind(&AlicaEngine::subscribe, this, std::placeholders::_1), configPath)
         , _masterPlan(_modelManager.loadPlanTree(masterPlanName))
         , _roleSet(_modelManager.loadRoleSet(roleSetName))
         , _teamManager(this, agentID)
@@ -183,11 +183,6 @@ void AlicaEngine::setStepEngine(bool stepEngine)
 const YAML::Node& AlicaEngine::getConfig() const
 {
     return _ctx.getConfig();
-}
-
-YAML::Node& AlicaEngine::editConfig()
-{
-    return _ctx.editConfig();
 }
 
 IAlicaWorldModel* AlicaEngine::getWorldModel() const

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -41,7 +41,7 @@ AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& configPath, const
         , _stepCalled(false)
         , _stepEngine(stepEngine)
         , _log(this)
-        , _modelManager(_planRepository, _ctx.getConfig(), std::bind(&AlicaEngine::subscribe, this, std::placeholders::_1), configPath)
+        , _modelManager(_planRepository, _ctx.editConfig(), std::bind(&AlicaEngine::subscribe, this, std::placeholders::_1), configPath)
         , _masterPlan(_modelManager.loadPlanTree(masterPlanName))
         , _roleSet(_modelManager.loadRoleSet(roleSetName))
         , _teamManager(this, agentID)
@@ -183,6 +183,11 @@ void AlicaEngine::setStepEngine(bool stepEngine)
 const YAML::Node& AlicaEngine::getConfig() const
 {
     return _ctx.getConfig();
+}
+
+YAML::Node& AlicaEngine::editConfig()
+{
+    return _ctx.editConfig();
 }
 
 IAlicaWorldModel* AlicaEngine::getWorldModel() const

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -41,7 +41,7 @@ AlicaEngine::AlicaEngine(AlicaContext& ctx, const std::string& configPath, const
         , _stepCalled(false)
         , _stepEngine(stepEngine)
         , _log(this)
-        , _modelManager(_planRepository, this, configPath)
+        , _modelManager(_planRepository, _ctx.getConfig(),std::bind(&AlicaEngine::subscribe, this, std::placeholders::_1), configPath)
         , _masterPlan(_modelManager.loadPlanTree(masterPlanName))
         , _roleSet(_modelManager.loadRoleSet(roleSetName))
         , _teamManager(this, agentID)

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -41,7 +41,7 @@ AlicaEngine::AlicaEngine(AlicaContext& ctx, YAML::Node& config, const std::strin
         , _stepCalled(false)
         , _stepEngine(stepEngine)
         , _log(this)
-        , _modelManager(_planRepository, config, std::bind(&AlicaEngine::subscribe, this, std::placeholders::_1), configPath)
+        , _modelManager(_planRepository, config, _configChangeListener, configPath)
         , _masterPlan(_modelManager.loadPlanTree(masterPlanName))
         , _roleSet(_modelManager.loadRoleSet(roleSetName))
         , _teamManager(this, agentID)
@@ -192,7 +192,7 @@ IAlicaWorldModel* AlicaEngine::getWorldModel() const
 
 void AlicaEngine::subscribe(std::function<void(const YAML::Node& config)> reloadFunction)
 {
-    _configChangeListenerCBs.push_back(reloadFunction);
+    _configChangeListener.subscribe(reloadFunction);
 };
 
 /**
@@ -231,8 +231,11 @@ AgentId AlicaEngine::generateID()
 
 void AlicaEngine::reloadConfig(const YAML::Node& config)
 {
-    for (auto reloadFunction : _configChangeListenerCBs) {
-        reloadFunction(config);
-    }
+    _configChangeListener.reloadConfig(config);
+}
+
+ConfigChangeListener& AlicaEngine::getConfigChangeListener()
+{
+    return _configChangeListener;
 }
 } // namespace alica

--- a/alica_engine/src/engine/ConfigChangeListener.cpp
+++ b/alica_engine/src/engine/ConfigChangeListener.cpp
@@ -1,0 +1,18 @@
+#include "engine/ConfigChangeListener.h"
+
+namespace alica
+{
+
+void ConfigChangeListener::subscribe(ReloadFunction reloadFunction)
+{
+    _configChangeListenerCBs.push_back(reloadFunction);
+};
+
+void ConfigChangeListener::reloadConfig(const YAML::Node& config)
+{
+    for (auto reloadFunction : _configChangeListenerCBs) {
+        reloadFunction(config);
+    }
+}
+
+} // namespace alica

--- a/alica_engine/src/engine/allocationauthority/CycleManager.cpp
+++ b/alica_engine/src/engine/allocationauthority/CycleManager.cpp
@@ -68,7 +68,7 @@ void CycleManager::update()
         return;
     }
 
-    const AbstractPlan* plan = _rp->getActivePlan();
+    const Plan* plan = dynamic_cast<const Plan*>(_rp->getActivePlan());
 
     if (_state == CycleState::observing) {
         if (detectAllocationCycle()) {
@@ -179,8 +179,8 @@ void CycleManager::handleAuthorityInfo(const AllocationAuthorityInfo& aai)
             ALICA_DEBUG_MSG("CM: Overriding assignment of " << _rp->getActivePlan()->getName());
 
             _state = CycleState::overriding;
-            _rp->getActivePlan()->setAuthorityTimeInterval(
-                    std::min(_maximalOverrideTimeInterval, (_rp->getActivePlan()->getAuthorityTimeInterval() * _intervalIncFactor)));
+            const Plan* plan = dynamic_cast<const Plan*>(_rp->getActivePlan());
+            plan->setAuthorityTimeInterval(std::min(_maximalOverrideTimeInterval, (plan->getAuthorityTimeInterval() * _intervalIncFactor)));
             _overrideTimestamp = _ae->getAlicaClock().now();
             _overrideShoutTime = AlicaTime::zero();
         }

--- a/alica_engine/src/engine/allocationauthority/CycleManager.cpp
+++ b/alica_engine/src/engine/allocationauthority/CycleManager.cpp
@@ -169,6 +169,11 @@ void CycleManager::handleAuthorityInfo(const AllocationAuthorityInfo& aai)
     if (!_enabled) {
         return;
     }
+
+    if (_rp->isBehaviour()) {
+        return;
+    }
+
     AgentId rid = aai.authority;
     if (rid == _myID) {
         return;

--- a/alica_engine/src/engine/model/AbstractPlan.cpp
+++ b/alica_engine/src/engine/model/AbstractPlan.cpp
@@ -13,42 +13,25 @@ AbstractPlan::AbstractPlan(AlicaEngine* ae)
         : AlicaElement()
 
 {
-    auto reloadFunctionPtr = std::bind(&AbstractPlan::reload, this, std::placeholders::_1);
-    ae->subscribe(reloadFunctionPtr);
-    reload(ae->getConfig());
 }
 
 AbstractPlan::AbstractPlan(AlicaEngine* ae, int64_t id)
         : AlicaElement(id)
 {
-    auto reloadFunctionPtr = std::bind(&AbstractPlan::reload, this, std::placeholders::_1);
-    ae->subscribe(reloadFunctionPtr);
-    reload(ae->getConfig());
 }
 
-AbstractPlan::AbstractPlan(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc)
+AbstractPlan::AbstractPlan(const YAML::Node& config)
         : AlicaElement()
 
 {
-    auto reloadFunctionPtr = std::bind(&AbstractPlan::reload, this, std::placeholders::_1);
-    subscribeFunc(reloadFunctionPtr);
-    reload(config);
 }
 
-AbstractPlan::AbstractPlan(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, int64_t id)
+AbstractPlan::AbstractPlan(const YAML::Node& config, int64_t id)
         : AlicaElement(id)
 {
-    auto reloadFunctionPtr = std::bind(&AbstractPlan::reload, this, std::placeholders::_1);
-    subscribeFunc(reloadFunctionPtr);
-    reload(config);
 }
 
 AbstractPlan::~AbstractPlan() {}
-
-void AbstractPlan::reload(const YAML::Node& config)
-{
-    _authorityTimeInterval = AlicaTime::milliseconds(config["Alica"]["CycleDetection"]["MinimalAuthorityTimeInterval"].as<unsigned long>());
-}
 
 std::string AbstractPlan::toString(std::string indent) const
 {
@@ -85,11 +68,6 @@ bool AbstractPlan::containsVar(const std::string& name) const
         }
     }
     return false;
-}
-
-void AbstractPlan::setAuthorityTimeInterval(AlicaTime authorithyTimeInterval) const
-{
-    _authorityTimeInterval = authorithyTimeInterval;
 }
 
 void AbstractPlan::setFileName(const std::string& fileName)

--- a/alica_engine/src/engine/model/AbstractPlan.cpp
+++ b/alica_engine/src/engine/model/AbstractPlan.cpp
@@ -26,6 +26,23 @@ AbstractPlan::AbstractPlan(AlicaEngine* ae, int64_t id)
     reload(ae->getConfig());
 }
 
+AbstractPlan::AbstractPlan(const YAML::Node& config, SubscribeFunction subscribeFunc)
+        : AlicaElement()
+
+{
+    auto reloadFunctionPtr = std::bind(&AbstractPlan::reload, this, std::placeholders::_1);
+    subscribeFunc(reloadFunctionPtr);
+    reload(config);
+}
+
+AbstractPlan::AbstractPlan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id)
+        : AlicaElement(id)
+{
+    auto reloadFunctionPtr = std::bind(&AbstractPlan::reload, this, std::placeholders::_1);
+    subscribeFunc(reloadFunctionPtr);
+    reload(config);
+}
+
 AbstractPlan::~AbstractPlan() {}
 
 void AbstractPlan::reload(const YAML::Node& config)

--- a/alica_engine/src/engine/model/AbstractPlan.cpp
+++ b/alica_engine/src/engine/model/AbstractPlan.cpp
@@ -26,7 +26,7 @@ AbstractPlan::AbstractPlan(AlicaEngine* ae, int64_t id)
     reload(ae->getConfig());
 }
 
-AbstractPlan::AbstractPlan(const YAML::Node& config, SubscribeFunction subscribeFunc)
+AbstractPlan::AbstractPlan(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc)
         : AlicaElement()
 
 {
@@ -35,7 +35,7 @@ AbstractPlan::AbstractPlan(const YAML::Node& config, SubscribeFunction subscribe
     reload(config);
 }
 
-AbstractPlan::AbstractPlan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id)
+AbstractPlan::AbstractPlan(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, int64_t id)
         : AlicaElement(id)
 {
     auto reloadFunctionPtr = std::bind(&AbstractPlan::reload, this, std::placeholders::_1);

--- a/alica_engine/src/engine/model/Behaviour.cpp
+++ b/alica_engine/src/engine/model/Behaviour.cpp
@@ -21,6 +21,17 @@ Behaviour::Behaviour(AlicaEngine* ae)
 {
 }
 
+Behaviour::Behaviour(const YAML::Node& config, SubscribeFunction subscribeFunc)
+        : _preCondition(nullptr)
+        , _runtimeCondition(nullptr)
+        , _postCondition(nullptr)
+        , _frequency(1)
+        , _deferring(0)
+        , _eventDriven(false)
+        , AbstractPlan(config,subscribeFunc)
+        , _blackboardBlueprint(nullptr)
+{}
+
 Behaviour::~Behaviour() {}
 
 std::string Behaviour::toString(std::string indent) const
@@ -42,6 +53,7 @@ std::string Behaviour::toString(std::string indent) const
     ss << indent << "#EndBehaviour" << std::endl;
     return ss.str();
 }
+
 
 void Behaviour::setEventDriven(bool eventDriven)
 {

--- a/alica_engine/src/engine/model/Behaviour.cpp
+++ b/alica_engine/src/engine/model/Behaviour.cpp
@@ -28,9 +28,10 @@ Behaviour::Behaviour(const YAML::Node& config, SubscribeFunction subscribeFunc)
         , _frequency(1)
         , _deferring(0)
         , _eventDriven(false)
-        , AbstractPlan(config,subscribeFunc)
+        , AbstractPlan(config, subscribeFunc)
         , _blackboardBlueprint(nullptr)
-{}
+{
+}
 
 Behaviour::~Behaviour() {}
 
@@ -53,7 +54,6 @@ std::string Behaviour::toString(std::string indent) const
     ss << indent << "#EndBehaviour" << std::endl;
     return ss.str();
 }
-
 
 void Behaviour::setEventDriven(bool eventDriven)
 {

--- a/alica_engine/src/engine/model/Behaviour.cpp
+++ b/alica_engine/src/engine/model/Behaviour.cpp
@@ -21,7 +21,7 @@ Behaviour::Behaviour(AlicaEngine* ae)
 {
 }
 
-Behaviour::Behaviour(const YAML::Node& config, SubscribeFunction subscribeFunc)
+Behaviour::Behaviour(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc)
         : _preCondition(nullptr)
         , _runtimeCondition(nullptr)
         , _postCondition(nullptr)

--- a/alica_engine/src/engine/model/Behaviour.cpp
+++ b/alica_engine/src/engine/model/Behaviour.cpp
@@ -21,14 +21,14 @@ Behaviour::Behaviour(AlicaEngine* ae)
 {
 }
 
-Behaviour::Behaviour(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc)
+Behaviour::Behaviour(const YAML::Node& config)
         : _preCondition(nullptr)
         , _runtimeCondition(nullptr)
         , _postCondition(nullptr)
         , _frequency(1)
         , _deferring(0)
         , _eventDriven(false)
-        , AbstractPlan(config, subscribeFunc)
+        , AbstractPlan(config)
         , _blackboardBlueprint(nullptr)
 {
 }

--- a/alica_engine/src/engine/model/Plan.cpp
+++ b/alica_engine/src/engine/model/Plan.cpp
@@ -9,12 +9,28 @@
 #include "engine/model/State.h"
 #include "engine/model/Task.h"
 #include "engine/model/Variable.h"
+#include "engine/model/Variable.h"
+
 //#include <alica_common_config/debug_output.h>
 
 namespace alica
 {
 Plan::Plan(AlicaEngine* ae, int64_t id)
         : AbstractPlan(ae, id)
+        , _minCardinality(0)
+        , _maxCardinality(0)
+        , _masterPlan(false)
+        , _utilityFunction(nullptr)
+        , _utilityThreshold(1.0)
+        , _runtimeCondition(nullptr)
+        , _preCondition(nullptr)
+        , _frequency(0)
+        , _blackboardBlueprint(nullptr)
+{
+}
+
+Plan::Plan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id)
+        : AbstractPlan(config,subscribeFunc, id)
         , _minCardinality(0)
         , _maxCardinality(0)
         , _masterPlan(false)

--- a/alica_engine/src/engine/model/Plan.cpp
+++ b/alica_engine/src/engine/model/Plan.cpp
@@ -9,7 +9,6 @@
 #include "engine/model/State.h"
 #include "engine/model/Task.h"
 #include "engine/model/Variable.h"
-#include "engine/model/Variable.h"
 
 //#include <alica_common_config/debug_output.h>
 
@@ -30,7 +29,7 @@ Plan::Plan(AlicaEngine* ae, int64_t id)
 }
 
 Plan::Plan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id)
-        : AbstractPlan(config,subscribeFunc, id)
+        : AbstractPlan(config, subscribeFunc, id)
         , _minCardinality(0)
         , _maxCardinality(0)
         , _masterPlan(false)

--- a/alica_engine/src/engine/model/Plan.cpp
+++ b/alica_engine/src/engine/model/Plan.cpp
@@ -28,7 +28,7 @@ Plan::Plan(AlicaEngine* ae, int64_t id)
 {
 }
 
-Plan::Plan(const YAML::Node& config, SubscribeFunction subscribeFunc, int64_t id)
+Plan::Plan(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, int64_t id)
         : AbstractPlan(config, subscribeFunc, id)
         , _minCardinality(0)
         , _maxCardinality(0)

--- a/alica_engine/src/engine/model/PlanType.cpp
+++ b/alica_engine/src/engine/model/PlanType.cpp
@@ -10,6 +10,11 @@ PlanType::PlanType(AlicaEngine* ae)
 {
 }
 
+PlanType::PlanType(const YAML::Node& config, SubscribeFunction subscribeFunc)
+        : AbstractPlan(config, subscribeFunc)
+{
+}
+
 PlanType::~PlanType() {}
 
 const Plan* PlanType::getPlanById(int64_t id) const

--- a/alica_engine/src/engine/model/PlanType.cpp
+++ b/alica_engine/src/engine/model/PlanType.cpp
@@ -10,8 +10,8 @@ PlanType::PlanType(AlicaEngine* ae)
 {
 }
 
-PlanType::PlanType(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc)
-        : AbstractPlan(config, subscribeFunc)
+PlanType::PlanType(const YAML::Node& config)
+        : AbstractPlan(config)
 {
 }
 

--- a/alica_engine/src/engine/model/PlanType.cpp
+++ b/alica_engine/src/engine/model/PlanType.cpp
@@ -10,7 +10,7 @@ PlanType::PlanType(AlicaEngine* ae)
 {
 }
 
-PlanType::PlanType(const YAML::Node& config, SubscribeFunction subscribeFunc)
+PlanType::PlanType(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc)
         : AbstractPlan(config, subscribeFunc)
 {
 }

--- a/alica_engine/src/engine/modelmanagement/ModelManager.cpp
+++ b/alica_engine/src/engine/modelmanagement/ModelManager.cpp
@@ -28,20 +28,18 @@ namespace alica
 
 ModelManager::ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder)
         : _planRepository(planRepository)
-        , _ae(ae)
-        , _config(ae->getConfig())
+        , _config(ae->getConfig())                                                      // temp
+        , _subscribeFunc(std::bind(&AlicaEngine::subscribe, ae, std::placeholders::_1)) // temp
         , domainConfigFolder(domainConfigFolder)
 {
     auto reloadFunctionPtr = std::bind(&ModelManager::reload, this, std::placeholders::_1);
-    _ae->subscribe(reloadFunctionPtr);
-    reload(_ae->getConfig());
+    _subscribeFunc(reloadFunctionPtr);
+    reload(_config);
     Factory::setModelManager(this);
-    //TODO add luca
 }
 
 ModelManager::ModelManager(PlanRepository& planRepository, const YAML::Node& config, SubscribeFunction subscribeFunc, const std::string& domainConfigFolder)
         : _planRepository(planRepository)
-        , _ae(nullptr) // to be removed in the last PR
         , _config(config)
         , _subscribeFunc(subscribeFunc)
         , domainConfigFolder(domainConfigFolder)
@@ -191,11 +189,11 @@ AlicaElement* ModelManager::parseFile(const std::string& currentFile, const std:
         AlicaEngine::abort("MM: Could not parse file: ", badFile.msg);
     }
     if (alica::Strings::plan.compare(type) == 0) {
-        Plan* plan = PlanFactory::create(_config,_subscribeFunc, node);
+        Plan* plan = PlanFactory::create(_config, _subscribeFunc, node);
         plan->setFileName(currentFile);
         return plan;
     } else if (alica::Strings::behaviour.compare(type) == 0) {
-        Behaviour* behaviour = BehaviourFactory::create(_config,_subscribeFunc, node);
+        Behaviour* behaviour = BehaviourFactory::create(_config, _subscribeFunc, node);
         behaviour->setFileName(currentFile);
         return behaviour;
     } else if (alica::Strings::configuration.compare(type) == 0) {
@@ -203,7 +201,7 @@ AlicaElement* ModelManager::parseFile(const std::string& currentFile, const std:
         configuration->setFileName(currentFile);
         return configuration;
     } else if (alica::Strings::plantype.compare(type) == 0) {
-        PlanType* planType = PlanTypeFactory::create(_config,_subscribeFunc, node);
+        PlanType* planType = PlanTypeFactory::create(_config, _subscribeFunc, node);
         planType->setFileName(currentFile);
         return planType;
     } else if (alica::Strings::taskrepository.compare(type) == 0) {

--- a/alica_engine/src/engine/modelmanagement/ModelManager.cpp
+++ b/alica_engine/src/engine/modelmanagement/ModelManager.cpp
@@ -28,7 +28,7 @@ namespace alica
 
 ModelManager::ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder)
         : _planRepository(planRepository)
-        , _config(ae->getConfig())                                                      // temp
+        , _config(ae->editConfig())                                                     // temp
         , _subscribeFunc(std::bind(&AlicaEngine::subscribe, ae, std::placeholders::_1)) // temp
         , domainConfigFolder(domainConfigFolder)
 {
@@ -38,7 +38,7 @@ ModelManager::ModelManager(PlanRepository& planRepository, AlicaEngine* ae, cons
     Factory::setModelManager(this);
 }
 
-ModelManager::ModelManager(PlanRepository& planRepository, const YAML::Node& config, SubscribeFunction subscribeFunc, const std::string& domainConfigFolder)
+ModelManager::ModelManager(PlanRepository& planRepository, YAML::Node& config, SubscribeFunction subscribeFunc, const std::string& domainConfigFolder)
         : _planRepository(planRepository)
         , _config(config)
         , _subscribeFunc(subscribeFunc)
@@ -52,6 +52,7 @@ ModelManager::ModelManager(PlanRepository& planRepository, const YAML::Node& con
 
 void ModelManager::reload(const YAML::Node& config)
 {
+    _config = config;
     basePlanPath = getBasePath("PlanDir");
     baseRolePath = getBasePath("RoleDir");
     baseTaskPath = getBasePath("TaskDir");

--- a/alica_engine/src/engine/modelmanagement/ModelManager.cpp
+++ b/alica_engine/src/engine/modelmanagement/ModelManager.cpp
@@ -28,7 +28,7 @@ namespace alica
 
 ModelManager::ModelManager(PlanRepository& planRepository, AlicaEngine* ae, const std::string& domainConfigFolder)
         : _planRepository(planRepository)
-        , _config(ae->editConfig())                                                     // temp
+        , _config(const_cast<YAML::Node&>(ae->getConfig()))                             // temp
         , _subscribeFunc(std::bind(&AlicaEngine::subscribe, ae, std::placeholders::_1)) // temp
         , domainConfigFolder(domainConfigFolder)
 {
@@ -38,7 +38,7 @@ ModelManager::ModelManager(PlanRepository& planRepository, AlicaEngine* ae, cons
     Factory::setModelManager(this);
 }
 
-ModelManager::ModelManager(PlanRepository& planRepository, YAML::Node& config, SubscribeFunction subscribeFunc, const std::string& domainConfigFolder)
+ModelManager::ModelManager(PlanRepository& planRepository, YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const std::string& domainConfigFolder)
         : _planRepository(planRepository)
         , _config(config)
         , _subscribeFunc(subscribeFunc)

--- a/alica_engine/src/engine/modelmanagement/factories/BehaviourFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/BehaviourFactory.cpp
@@ -43,9 +43,9 @@ Behaviour* BehaviourFactory::create(AlicaEngine* ae, const YAML::Node& node)
     return behaviour;
 }
 
-Behaviour* BehaviourFactory::create(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const YAML::Node& node)
+Behaviour* BehaviourFactory::create(const YAML::Node& config,  const YAML::Node& node)
 {
-    Behaviour* behaviour = new Behaviour(config, subscribeFunc);
+    Behaviour* behaviour = new Behaviour(config);
     Factory::setAttributes(node, behaviour);
     Factory::storeElement(behaviour, alica::Strings::behaviour);
     AbstractPlanFactory::setVariables(node, behaviour);

--- a/alica_engine/src/engine/modelmanagement/factories/BehaviourFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/BehaviourFactory.cpp
@@ -45,7 +45,7 @@ Behaviour* BehaviourFactory::create(AlicaEngine* ae, const YAML::Node& node)
 
 Behaviour* BehaviourFactory::create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node)
 {
-Behaviour* behaviour = new Behaviour(config,subscribeFunc);
+    Behaviour* behaviour = new Behaviour(config, subscribeFunc);
     Factory::setAttributes(node, behaviour);
     Factory::storeElement(behaviour, alica::Strings::behaviour);
     AbstractPlanFactory::setVariables(node, behaviour);
@@ -73,9 +73,8 @@ Behaviour* behaviour = new Behaviour(config,subscribeFunc);
     } else {
         behaviour->_blackboardBlueprint = nullptr;
     }
-    return behaviour;    
+    return behaviour;
 }
-
 
 void BehaviourFactory::attachReferences()
 {

--- a/alica_engine/src/engine/modelmanagement/factories/BehaviourFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/BehaviourFactory.cpp
@@ -43,7 +43,7 @@ Behaviour* BehaviourFactory::create(AlicaEngine* ae, const YAML::Node& node)
     return behaviour;
 }
 
-Behaviour* BehaviourFactory::create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node)
+Behaviour* BehaviourFactory::create(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const YAML::Node& node)
 {
     Behaviour* behaviour = new Behaviour(config, subscribeFunc);
     Factory::setAttributes(node, behaviour);

--- a/alica_engine/src/engine/modelmanagement/factories/BehaviourFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/BehaviourFactory.cpp
@@ -43,6 +43,40 @@ Behaviour* BehaviourFactory::create(AlicaEngine* ae, const YAML::Node& node)
     return behaviour;
 }
 
+Behaviour* BehaviourFactory::create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node)
+{
+Behaviour* behaviour = new Behaviour(config,subscribeFunc);
+    Factory::setAttributes(node, behaviour);
+    Factory::storeElement(behaviour, alica::Strings::behaviour);
+    AbstractPlanFactory::setVariables(node, behaviour);
+
+    behaviour->_frequency = Factory::getValue<int>(node, alica::Strings::frequency, 1);
+    behaviour->_deferring = Factory::getValue<int>(node, alica::Strings::deferring, 0);
+    behaviour->_eventDriven = Factory::getValue<bool>(node, alica::Strings::eventDriven, false);
+
+    if (Factory::isValid(node[alica::Strings::preCondition])) {
+        behaviour->_preCondition = PreConditionFactory::create(node[alica::Strings::preCondition], behaviour);
+    }
+    if (Factory::isValid(node[alica::Strings::runtimeCondition])) {
+        behaviour->_runtimeCondition = RuntimeConditionFactory::create(node[alica::Strings::runtimeCondition], behaviour);
+    }
+    if (Factory::isValid(node[alica::Strings::postCondition])) {
+        behaviour->_postCondition = PostConditionFactory::create(node[alica::Strings::postCondition], behaviour);
+    }
+    auto inheritBlackboard = Factory::getValue<bool>(node, alica::Strings::inheritBlackboard, true);
+    if (!inheritBlackboard) {
+        if (Factory::isValid(node[alica::Strings::blackboard])) {
+            behaviour->_blackboardBlueprint = std::move(BlackboardBlueprintFactory::create(node[alica::Strings::blackboard]));
+        } else {
+            behaviour->_blackboardBlueprint = std::move(BlackboardBlueprintFactory::createEmpty());
+        }
+    } else {
+        behaviour->_blackboardBlueprint = nullptr;
+    }
+    return behaviour;    
+}
+
+
 void BehaviourFactory::attachReferences()
 {
     ConditionFactory::attachReferences();

--- a/alica_engine/src/engine/modelmanagement/factories/BehaviourFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/BehaviourFactory.cpp
@@ -43,7 +43,7 @@ Behaviour* BehaviourFactory::create(AlicaEngine* ae, const YAML::Node& node)
     return behaviour;
 }
 
-Behaviour* BehaviourFactory::create(const YAML::Node& config,  const YAML::Node& node)
+Behaviour* BehaviourFactory::create(const YAML::Node& config, const YAML::Node& node)
 {
     Behaviour* behaviour = new Behaviour(config);
     Factory::setAttributes(node, behaviour);

--- a/alica_engine/src/engine/modelmanagement/factories/PlanFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/PlanFactory.cpp
@@ -114,7 +114,7 @@ Plan* PlanFactory::create(AlicaEngine* ae, const YAML::Node& node)
     return plan;
 }
 
-Plan* PlanFactory::create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node)
+Plan* PlanFactory::create(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const YAML::Node& node)
 {
     Plan* plan = new Plan(config, subscribeFunc, Factory::getValue<int64_t>(node, alica::Strings::id));
     Factory::setAttributes(node, plan);

--- a/alica_engine/src/engine/modelmanagement/factories/PlanFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/PlanFactory.cpp
@@ -114,9 +114,9 @@ Plan* PlanFactory::create(AlicaEngine* ae, const YAML::Node& node)
     return plan;
 }
 
-Plan* PlanFactory::create(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const YAML::Node& node)
+Plan* PlanFactory::create(const YAML::Node& config, ConfigChangeListener& configChangeListener, const YAML::Node& node)
 {
-    Plan* plan = new Plan(config, subscribeFunc, Factory::getValue<int64_t>(node, alica::Strings::id));
+    Plan* plan = new Plan(config, configChangeListener, Factory::getValue<int64_t>(node, alica::Strings::id));
     Factory::setAttributes(node, plan);
     Factory::storeElement(plan, alica::Strings::plan);
     AbstractPlanFactory::setVariables(node, plan);

--- a/alica_engine/src/engine/modelmanagement/factories/PlanFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/PlanFactory.cpp
@@ -114,10 +114,9 @@ Plan* PlanFactory::create(AlicaEngine* ae, const YAML::Node& node)
     return plan;
 }
 
-
 Plan* PlanFactory::create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node)
 {
-    Plan* plan = new Plan(config,subscribeFunc, Factory::getValue<int64_t>(node, alica::Strings::id));
+    Plan* plan = new Plan(config, subscribeFunc, Factory::getValue<int64_t>(node, alica::Strings::id));
     Factory::setAttributes(node, plan);
     Factory::storeElement(plan, alica::Strings::plan);
     AbstractPlanFactory::setVariables(node, plan);

--- a/alica_engine/src/engine/modelmanagement/factories/PlanFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/PlanFactory.cpp
@@ -114,6 +114,97 @@ Plan* PlanFactory::create(AlicaEngine* ae, const YAML::Node& node)
     return plan;
 }
 
+
+Plan* PlanFactory::create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& node)
+{
+    Plan* plan = new Plan(config,subscribeFunc, Factory::getValue<int64_t>(node, alica::Strings::id));
+    Factory::setAttributes(node, plan);
+    Factory::storeElement(plan, alica::Strings::plan);
+    AbstractPlanFactory::setVariables(node, plan);
+
+    if (Factory::isValid(node[alica::Strings::masterPlan])) {
+        plan->_masterPlan = node[alica::Strings::masterPlan].as<bool>();
+    }
+    if (Factory::isValid(node[alica::Strings::frequency])) {
+        plan->_frequency = node[alica::Strings::frequency].as<int>();
+    }
+    if (Factory::isValid(node[alica::Strings::utilityThreshold])) {
+        plan->_utilityThreshold = node[alica::Strings::utilityThreshold].as<double>();
+    }
+    if (Factory::isValid(node[alica::Strings::entryPoints])) {
+        std::vector<EntryPoint*> entryPoints = EntryPointFactory::create(node[alica::Strings::entryPoints]);
+        // add to plan and summarize min/max cardinality
+        int minCard = 0;
+        int maxCard = 0;
+        plan->_entryPoints.reserve(entryPoints.size());
+        for (int i = 0; i < static_cast<int>(entryPoints.size()); ++i) {
+            plan->_entryPoints.push_back(entryPoints[i]);
+            minCard += entryPoints[i]->getCardinality().getMin();
+            // avoid overflow for maxCard
+            long tmpMax = maxCard;
+            if (tmpMax + entryPoints[i]->getCardinality().getMax() > INT32_MAX) {
+                maxCard = INT32_MAX;
+            } else {
+                maxCard += entryPoints[i]->getCardinality().getMax();
+            }
+        }
+        plan->setMinCardinality(minCard);
+        plan->setMaxCardinality(maxCard);
+    }
+    if (Factory::isValid(node[alica::Strings::states])) {
+        const YAML::Node& states = node[alica::Strings::states];
+        for (YAML::const_iterator it = states.begin(); it != states.end(); ++it) {
+            State* state = nullptr;
+            std::string stateType = Factory::getValue<std::string>(*it, alica::Strings::stateType);
+            if (stateType.compare(alica::Strings::terminalStateType) == 0) {
+                state = TerminalStateFactory::create(*it, plan);
+            } else if (stateType.compare(alica::Strings::normalStateType) == 0) {
+                state = StateFactory::create(*it);
+            } else {
+                std::cerr << "[PlanFactory] Unknown state type encountered: '" << stateType << std::endl;
+            }
+            plan->_states.push_back(state);
+            if (state->isFailureState()) {
+                plan->_failureStates.push_back((FailureState*) state);
+            }
+            if (state->isSuccessState()) {
+                plan->_successStates.push_back((SuccessState*) state);
+            }
+        }
+    }
+    if (Factory::isValid(node[alica::Strings::transitions])) {
+        const YAML::Node& transitions = node[alica::Strings::transitions];
+        for (YAML::const_iterator it = transitions.begin(); it != transitions.end(); ++it) {
+            plan->_transitions.push_back(TransitionFactory::create(*it, plan));
+        }
+    }
+    if (Factory::isValid(node[alica::Strings::preCondition])) {
+        plan->_preCondition = PreConditionFactory::create(node[alica::Strings::preCondition], plan);
+    }
+    if (Factory::isValid(node[alica::Strings::runtimeCondition])) {
+        plan->_runtimeCondition = RuntimeConditionFactory::create(node[alica::Strings::runtimeCondition], plan);
+    }
+    if (Factory::isValid(node[alica::Strings::synchronisations])) {
+        const YAML::Node& synchronisations = node[alica::Strings::synchronisations];
+        for (YAML::const_iterator it = synchronisations.begin(); it != synchronisations.end(); ++it) {
+            plan->_synchronisations.push_back(SynchronisationFactory::create(*it, plan));
+        }
+    }
+
+    auto inheritBlackboard = Factory::getValue<bool>(node, alica::Strings::inheritBlackboard, true);
+
+    if (!inheritBlackboard) {
+        if (Factory::isValid(node[alica::Strings::blackboard])) {
+            plan->_blackboardBlueprint = std::move(BlackboardBlueprintFactory::create(node[alica::Strings::blackboard]));
+        } else {
+            plan->_blackboardBlueprint = std::move(BlackboardBlueprintFactory::createEmpty());
+        }
+    } else {
+        plan->_blackboardBlueprint = nullptr;
+    }
+    return plan;
+}
+
 void PlanFactory::attachReferences()
 {
     EntryPointFactory::attachReferences();

--- a/alica_engine/src/engine/modelmanagement/factories/PlanTypeFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/PlanTypeFactory.cpp
@@ -37,9 +37,9 @@ PlanType* PlanTypeFactory::create(AlicaEngine* ae, const YAML::Node& planTypeNod
     return planType;
 }
 
-PlanType* PlanTypeFactory::create(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const YAML::Node& planTypeNode)
+PlanType* PlanTypeFactory::create(const YAML::Node& config,  const YAML::Node& planTypeNode)
 {
-    PlanType* planType = new PlanType(config, subscribeFunc);
+    PlanType* planType = new PlanType(config);
     Factory::setAttributes(planTypeNode, planType);
     Factory::storeElement(planType, alica::Strings::plantype);
     AbstractPlanFactory::setVariables(planTypeNode, planType);

--- a/alica_engine/src/engine/modelmanagement/factories/PlanTypeFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/PlanTypeFactory.cpp
@@ -37,6 +37,34 @@ PlanType* PlanTypeFactory::create(AlicaEngine* ae, const YAML::Node& planTypeNod
     return planType;
 }
 
+PlanType* PlanTypeFactory::create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& planTypeNode)
+{
+    PlanType* planType = new PlanType(config,subscribeFunc);
+    Factory::setAttributes(planTypeNode, planType);
+    Factory::storeElement(planType, alica::Strings::plantype);
+    AbstractPlanFactory::setVariables(planTypeNode, planType);
+
+    if (Factory::isValid(planTypeNode[alica::Strings::annotatedPlans])) {
+        const YAML::Node& annotatedPlanNodes = planTypeNode[alica::Strings::annotatedPlans];
+        for (YAML::const_iterator it = annotatedPlanNodes.begin(); it != annotatedPlanNodes.end(); ++it) {
+            // only add plans that are annotated to be active
+            if (Factory::getValue<bool>(*it, alica::Strings::activated, false)) {
+                const std::string& referencedPlanString = Factory::getValue<std::string>(*it, alica::Strings::plan);
+                Factory::planTypePlanReferences.push_back(std::pair<int64_t, int64_t>(planType->getId(), Factory::getReferencedId(referencedPlanString)));
+            }
+        }
+    }
+
+    if (Factory::isValid(planTypeNode[alica::Strings::variableBindings])) {
+        const YAML::Node& variableBindings = planTypeNode[alica::Strings::variableBindings];
+        for (YAML::const_iterator it = variableBindings.begin(); it != variableBindings.end(); ++it) {
+            planType->_variableBindings.push_back(VariableBindingFactory::create(*it));
+        }
+    }
+
+    return planType;
+}
+
 void PlanTypeFactory::attachReferences()
 {
     VariableBindingFactory::attachReferences();

--- a/alica_engine/src/engine/modelmanagement/factories/PlanTypeFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/PlanTypeFactory.cpp
@@ -37,7 +37,7 @@ PlanType* PlanTypeFactory::create(AlicaEngine* ae, const YAML::Node& planTypeNod
     return planType;
 }
 
-PlanType* PlanTypeFactory::create(const YAML::Node& config,  const YAML::Node& planTypeNode)
+PlanType* PlanTypeFactory::create(const YAML::Node& config, const YAML::Node& planTypeNode)
 {
     PlanType* planType = new PlanType(config);
     Factory::setAttributes(planTypeNode, planType);

--- a/alica_engine/src/engine/modelmanagement/factories/PlanTypeFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/PlanTypeFactory.cpp
@@ -39,7 +39,7 @@ PlanType* PlanTypeFactory::create(AlicaEngine* ae, const YAML::Node& planTypeNod
 
 PlanType* PlanTypeFactory::create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& planTypeNode)
 {
-    PlanType* planType = new PlanType(config,subscribeFunc);
+    PlanType* planType = new PlanType(config, subscribeFunc);
     Factory::setAttributes(planTypeNode, planType);
     Factory::storeElement(planType, alica::Strings::plantype);
     AbstractPlanFactory::setVariables(planTypeNode, planType);

--- a/alica_engine/src/engine/modelmanagement/factories/PlanTypeFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/PlanTypeFactory.cpp
@@ -37,7 +37,7 @@ PlanType* PlanTypeFactory::create(AlicaEngine* ae, const YAML::Node& planTypeNod
     return planType;
 }
 
-PlanType* PlanTypeFactory::create(const YAML::Node& config, SubscribeFunction subscribeFunc, const YAML::Node& planTypeNode)
+PlanType* PlanTypeFactory::create(const YAML::Node& config, ConfigChangeSubscriber subscribeFunc, const YAML::Node& planTypeNode)
 {
     PlanType* planType = new PlanType(config, subscribeFunc);
     Factory::setAttributes(planTypeNode, planType);


### PR DESCRIPTION
The first step for removing AlicaEngine `this` around. This PR involves the class ModelManager and related classes.
The constructors, for now, are only deprecated.