### PR TITLE
Add configurable auto failure handling capability

### DIFF
--- a/alica_engine/include/engine/RuleBook.h
+++ b/alica_engine/include/engine/RuleBook.h
@@ -49,6 +49,7 @@ private:
     PlanBase* _pb;
     Logger& _log;
     int _maxConsecutiveChanges;
+    bool _autoFailureHandlingEnabled;
     bool _changeOccurred;
     const IAlicaWorldModel* _wm;
 

--- a/alica_engine/src/engine/RuleBook.cpp
+++ b/alica_engine/src/engine/RuleBook.cpp
@@ -229,8 +229,6 @@ PlanChange RuleBook::authorityOverrideRule(RunningPlan& r)
  */
 PlanChange RuleBook::planAbortRule(RunningPlan& r)
 {
-    if (!_autoFailureHandlingEnabled)
-        return PlanChange::NoChange;
     assert(!r.isRetired());
     if (r.isFailureHandlingNeeded())
         return PlanChange::NoChange;

--- a/alica_engine/src/engine/RuleBook.cpp
+++ b/alica_engine/src/engine/RuleBook.cpp
@@ -55,6 +55,7 @@ void RuleBook::init(const IAlicaWorldModel* wm)
 void RuleBook::reload(const YAML::Node& config)
 {
     _maxConsecutiveChanges = config["Alica"]["MaxRuleApplications"].as<int>();
+    _autoFailureHandlingEnabled = config["Alica"]["AutoFailureHandling"].as<bool>();
 }
 
 /**
@@ -228,6 +229,8 @@ PlanChange RuleBook::authorityOverrideRule(RunningPlan& r)
  */
 PlanChange RuleBook::planAbortRule(RunningPlan& r)
 {
+    if (!_autoFailureHandlingEnabled)
+        return PlanChange::NoChange;
     assert(!r.isRetired());
     if (r.isFailureHandlingNeeded())
         return PlanChange::NoChange;
@@ -257,6 +260,9 @@ PlanChange RuleBook::planAbortRule(RunningPlan& r)
  */
 PlanChange RuleBook::planRedoRule(RunningPlan& r)
 {
+    if (!_autoFailureHandlingEnabled)
+        return PlanChange::NoChange;
+
     assert(!r.isRetired());
     ALICA_DEBUG_MSG("RB: PlanRedoRule-Rule called.");
     ALICA_DEBUG_MSG("RB: PlanRedoRule RP \n" << r);
@@ -295,6 +301,9 @@ PlanChange RuleBook::planRedoRule(RunningPlan& r)
  */
 PlanChange RuleBook::planReplaceRule(RunningPlan& r)
 {
+    if (!_autoFailureHandlingEnabled)
+        return PlanChange::NoChange;
+
     assert(!r.isRetired());
     ALICA_DEBUG_MSG("RB: PlanReplace-Rule called.");
     ALICA_DEBUG_MSG("RB: PlanReplace RP \n" << r);
@@ -325,6 +334,9 @@ PlanChange RuleBook::planReplaceRule(RunningPlan& r)
  */
 PlanChange RuleBook::planPropagationRule(RunningPlan& r)
 {
+    if (!_autoFailureHandlingEnabled)
+        return PlanChange::NoChange;
+
     assert(!r.isRetired());
     ALICA_DEBUG_MSG("RB: PlanPropagation-Rule called.");
     ALICA_DEBUG_MSG("RB: PlanPropagation RP \n" << r);
@@ -389,6 +401,9 @@ PlanChange RuleBook::allocationRule(RunningPlan& rp)
  */
 PlanChange RuleBook::topFailRule(RunningPlan& r)
 {
+    if (!_autoFailureHandlingEnabled)
+        return PlanChange::NoChange;
+
     assert(!r.isRetired());
     ALICA_DEBUG_MSG("RB: TopFail-Rule called.");
     ALICA_DEBUG_MSG("RB: TopFail RP \n" << r);

--- a/alica_test_utility/include/alica/test/Util.h
+++ b/alica_test_utility/include/alica/test/Util.h
@@ -7,7 +7,7 @@
 #include <chrono>
 #include <memory>
 
-#define STEP_UNTIL(condition)                                                                                                                                  \
+#define STEP_UNTIL1(condition)                                                                                                                                 \
     do {                                                                                                                                                       \
         for (int i = 0; i < 10; ++i) {                                                                                                                         \
             ac->stepEngine();                                                                                                                                  \
@@ -17,6 +17,20 @@
             std::this_thread::sleep_for(std::chrono::milliseconds(10));                                                                                        \
         }                                                                                                                                                      \
     } while (0)
+
+#define STEP_UNTIL2(ac, condition)                                                                                                                             \
+    do {                                                                                                                                                       \
+        for (int i = 0; i < 10; ++i) {                                                                                                                         \
+            (ac)->stepEngine();                                                                                                                                \
+            if (condition) {                                                                                                                                   \
+                break;                                                                                                                                         \
+            }                                                                                                                                                  \
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));                                                                                        \
+        }                                                                                                                                                      \
+    } while (0)
+
+#define GET_STEP_MACRO(_0, _1, _2, NAME, ...) NAME
+#define STEP_UNTIL(...) GET_STEP_MACRO(_0, __VA_ARGS__, STEP_UNTIL2, STEP_UNTIL1)(__VA_ARGS__)
 
 #define SLEEP_UNTIL(condition)                                                                                                                                 \
     do {                                                                                                                                                       \

--- a/alica_tests/include/alica_tests/TestWorldModel.h
+++ b/alica_tests/include/alica_tests/TestWorldModel.h
@@ -75,8 +75,8 @@ public:
     void reset();
 
     // Failure handling tests
-    void setTransitionCondition3194919312481305139(bool value);
-    bool isTransitionCondition3194919312481305139() const;
+    void enableTransitionCondition3194919312481305139();
+    bool transitionCondition3194919312481305139Enabled() const;
     void setTransitionCondition1446293122737278544(bool value);
     bool isTransitionCondition1446293122737278544() const;
     void setTransitionCondition1023566846009251524(bool value);

--- a/alica_tests/include/alica_tests/TestWorldModel.h
+++ b/alica_tests/include/alica_tests/TestWorldModel.h
@@ -75,6 +75,8 @@ public:
     void reset();
 
     // Failure handling tests
+    void failurePlanInitCalled();
+    int failurePlanInitCallCount() const;
     void enableTransitionCondition3194919312481305139();
     bool transitionCondition3194919312481305139Enabled() const;
     void setTransitionCondition1446293122737278544(bool value);
@@ -118,6 +120,7 @@ private:
     bool switchEntryPoints;
 
     // Failure handling tests
+    std::atomic<int> failurePlanInitCallCounter;
     std::atomic<bool> transitionCondition3194919312481305139;
     std::atomic<bool> transitionCondition1446293122737278544;
     std::atomic<bool> transitionCondition1023566846009251524;

--- a/alica_tests/src/TestWorldModel.cpp
+++ b/alica_tests/src/TestWorldModel.cpp
@@ -221,12 +221,11 @@ void TestWorldModel::setPreCondition1840401110297459509(bool preCondition1840401
 {
     this->preCondition1840401110297459509 = preCondition1840401110297459509;
 }
-
-void TestWorldModel::setTransitionCondition3194919312481305139(bool value)
+void TestWorldModel::enableTransitionCondition3194919312481305139()
 {
-    transitionCondition3194919312481305139 = value;
+    transitionCondition3194919312481305139 = true;
 }
-bool TestWorldModel::isTransitionCondition3194919312481305139() const
+bool TestWorldModel::transitionCondition3194919312481305139Enabled() const
 {
     return transitionCondition3194919312481305139;
 }

--- a/alica_tests/src/TestWorldModel.cpp
+++ b/alica_tests/src/TestWorldModel.cpp
@@ -46,6 +46,7 @@ void TestWorldModel::reset()
     tracingTags.clear();
     tracingParents.clear();
 
+    failurePlanInitCallCounter = 0;
     transitionCondition3194919312481305139 = false;
     transitionCondition1446293122737278544 = false;
     transitionCondition1023566846009251524 = false;
@@ -220,6 +221,14 @@ bool TestWorldModel::isPreCondition1840401110297459509() const
 void TestWorldModel::setPreCondition1840401110297459509(bool preCondition1840401110297459509)
 {
     this->preCondition1840401110297459509 = preCondition1840401110297459509;
+}
+void TestWorldModel::failurePlanInitCalled()
+{
+    ++failurePlanInitCallCounter;
+}
+int TestWorldModel::failurePlanInitCallCount() const
+{
+    return failurePlanInitCallCounter;
 }
 void TestWorldModel::enableTransitionCondition3194919312481305139()
 {

--- a/alica_tests/src/test/Expr/include/alica_tests/FailurePlan631515556091266493.h
+++ b/alica_tests/src/test/Expr/include/alica_tests/FailurePlan631515556091266493.h
@@ -26,7 +26,7 @@ protected:
     /*PROTECTED REGION ID(pro631515556091266493) ENABLED START*/
     // Override these methods for your use case
     // virtual void run(void* msg) override;
-    // virtual void onInit() override;
+    virtual void onInit() override;
     // virtual void onTerminate() override;
     // Add additional protected methods here
     /*PROTECTED REGION END*/

--- a/alica_tests/src/test/Expr/src/FailureHandlingMaster4150733089768927549.cpp
+++ b/alica_tests/src/test/Expr/src/FailureHandlingMaster4150733089768927549.cpp
@@ -57,8 +57,11 @@ std::shared_ptr<UtilityFunction> UtilityFunction4150733089768927549::getUtilityF
 bool PreCondition488794245455049811::evaluate(std::shared_ptr<RunningPlan> rp, const IAlicaWorldModel* wm)
 {
     /*PROTECTED REGION ID(3194919312481305139) ENABLED START*/
-    const auto twm = dynamic_cast<const alicaTests::TestWorldModel*>(wm);
-    return twm->isTransitionCondition3194919312481305139();
+    const auto twm = rp->getOwnID() == 8 ? alicaTests::TestWorldModel::getOne() : alicaTests::TestWorldModel::getTwo();
+    if (twm->transitionCondition3194919312481305139Enabled()) {
+        return rp->isAnyChildStatus(PlanStatus::Failed);
+    }
+    return false;
     /*PROTECTED REGION END*/
 }
 

--- a/alica_tests/src/test/Expr/src/FailurePlan631515556091266493.cpp
+++ b/alica_tests/src/test/Expr/src/FailurePlan631515556091266493.cpp
@@ -86,5 +86,10 @@ bool PreCondition2038762164340314344::evaluate(std::shared_ptr<RunningPlan> rp, 
 
 /*PROTECTED REGION ID(methods631515556091266493) ENABLED START*/
 // Add additional options here
+void FailurePlan631515556091266493::onInit()
+{
+    auto twm = getPlanContext()->getOwnID() == 8 ? alicaTests::TestWorldModel::getOne() : alicaTests::TestWorldModel::getTwo();
+    twm->failurePlanInitCalled();
+}
 /*PROTECTED REGION END*/
 } // namespace alica

--- a/alica_tests/src/test/Expr/src/FailurePlan631515556091266493.cpp
+++ b/alica_tests/src/test/Expr/src/FailurePlan631515556091266493.cpp
@@ -57,7 +57,7 @@ std::shared_ptr<UtilityFunction> UtilityFunction631515556091266493::getUtilityFu
 bool PreCondition4351457352348187886::evaluate(std::shared_ptr<RunningPlan> rp, const IAlicaWorldModel* wm)
 {
     /*PROTECTED REGION ID(1446293122737278544) ENABLED START*/
-    const auto twm = dynamic_cast<const alicaTests::TestWorldModel*>(wm);
+    const auto twm = rp->getOwnID() == 8 ? alicaTests::TestWorldModel::getOne() : alicaTests::TestWorldModel::getTwo();
     return twm->isTransitionCondition1446293122737278544();
     /*PROTECTED REGION END*/
 }
@@ -79,7 +79,7 @@ bool PreCondition4351457352348187886::evaluate(std::shared_ptr<RunningPlan> rp, 
 bool PreCondition2038762164340314344::evaluate(std::shared_ptr<RunningPlan> rp, const IAlicaWorldModel* wm)
 {
     /*PROTECTED REGION ID(1023566846009251524) ENABLED START*/
-    const auto twm = dynamic_cast<const alicaTests::TestWorldModel*>(wm);
+    const auto twm = rp->getOwnID() == 8 ? alicaTests::TestWorldModel::getOne() : alicaTests::TestWorldModel::getTwo();
     return twm->isTransitionCondition1023566846009251524();
     /*PROTECTED REGION END*/
 }

--- a/alica_tests/src/test/etc/hairy/Alica.yaml
+++ b/alica_tests/src/test/etc/hairy/Alica.yaml
@@ -27,6 +27,9 @@ Alica:
   TeamTimeOut: 10000
   AssignmentProtectionTime: 500
 
+  #Failure Handling
+  AutoFailureHandling: true
+
   #Hz
   MinBroadcastFrequency: 10
   MaxBroadcastFrequency: 15
@@ -82,4 +85,3 @@ Alica:
     SeedTTL4Usage: 5000
     MaxSolveTime: 10
     MaxFunctionEvaluations: 100000000
-

--- a/alica_tests/src/test/etc/nase/Alica.yaml
+++ b/alica_tests/src/test/etc/nase/Alica.yaml
@@ -24,6 +24,9 @@ Alica:
   TeamTimeOut: 10000
   AssignmentProtectionTime: 500
 
+  #Failure Handling
+  AutoFailureHandling: true
+
   #Hz
   MinBroadcastFrequency: 10
   MaxBroadcastFrequency: 15
@@ -79,4 +82,3 @@ Alica:
     SeedTTL4Usage: 5000
     MaxSolveTime: 10
     MaxFunctionEvaluations: 100000000
-

--- a/alica_tests/src/test/test_failure_handling.cpp
+++ b/alica_tests/src/test/test_failure_handling.cpp
@@ -79,6 +79,7 @@ TEST_F(AlicaFailureHandlingEnabledFixture, redoPlanOnFailure)
     wm->setTransitionCondition1446293122737278544(false);
     STEP_UNTIL(test::Util::isStateActive(ae, FAILURE_PLAN_INIT_STATE));
     ASSERT_TRUE(test::Util::isStateActive(ae, FAILURE_PLAN_INIT_STATE));
+    ASSERT_EQ(wm->failurePlanInitCallCount(), 1);
 }
 
 TEST_F(AlicaFailureHandlingDisabledFixture, autoFailureHandlingDisabledTest)
@@ -86,6 +87,7 @@ TEST_F(AlicaFailureHandlingDisabledFixture, autoFailureHandlingDisabledTest)
     // Checks if nothing is done when a plan failure occurs when auto failure handling is disabled
     auto wm = alicaTests::TestWorldModel::getTwo();
     const uint64_t FAILURE_PLAN_INIT_STATE = 1171453089016322268;
+    const uint64_t FAILURE_PLAN_FAIL_STATE = 3487518754011112127;
     const uint64_t FAILURE_PLAN_FAILED_STATE = 3748960977005112327;
     const uint64_t FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE = 4449850763179483831;
 
@@ -94,6 +96,10 @@ TEST_F(AlicaFailureHandlingDisabledFixture, autoFailureHandlingDisabledTest)
     ASSERT_TRUE(test::Util::isStateActive(ae, FAILURE_PLAN_INIT_STATE));
 
     wm->setTransitionCondition1446293122737278544(true);
+    STEP_UNTIL(test::Util::isStateActive(ae, FAILURE_PLAN_FAIL_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(ae, FAILURE_PLAN_FAIL_STATE));
+
+    wm->setTransitionCondition1446293122737278544(false);
     wm->setTransitionCondition1023566846009251524(true);
     STEP_UNTIL(test::Util::isStateActive(ae, FAILURE_PLAN_FAILED_STATE));
     ASSERT_TRUE(test::Util::isStateActive(ae, FAILURE_PLAN_FAILED_STATE));
@@ -108,6 +114,7 @@ TEST_F(AlicaFailureHandlingDisabledFixture, autoFailureHandlingDisabledTest)
     wm->enableTransitionCondition3194919312481305139();
     STEP_UNTIL(test::Util::isStateActive(ae, FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE));
     ASSERT_TRUE(test::Util::isStateActive(ae, FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE));
+    ASSERT_EQ(wm->failurePlanInitCallCount(), 1);
 }
 
 TEST_F(AlicaFailureHandlingEnabledMultiAgentFixture, redoPlanOnFailureMultiAgent)
@@ -142,6 +149,8 @@ TEST_F(AlicaFailureHandlingEnabledMultiAgentFixture, redoPlanOnFailureMultiAgent
     ASSERT_TRUE(test::Util::isStateActive(aes[0], FAILURE_PLAN_INIT_STATE));
     STEP_UNTIL(acs[1], test::Util::isStateActive(aes[1], FAILURE_PLAN_FAIL_STATE));
     ASSERT_TRUE(test::Util::isStateActive(aes[1], FAILURE_PLAN_FAIL_STATE));
+    ASSERT_EQ(wm0->failurePlanInitCallCount(), 1);
+    ASSERT_EQ(wm1->failurePlanInitCallCount(), 1);
 }
 
 TEST_F(AlicaFailureHandlingDisabledMultiAgentFixture, autoFailureHandlingDisabledMultiAgentTest)
@@ -150,6 +159,7 @@ TEST_F(AlicaFailureHandlingDisabledMultiAgentFixture, autoFailureHandlingDisable
     auto wm0 = alicaTests::TestWorldModel::getOne();
     auto wm1 = alicaTests::TestWorldModel::getTwo();
     const uint64_t FAILURE_PLAN_INIT_STATE = 1171453089016322268;
+    const uint64_t FAILURE_PLAN_FAIL_STATE = 3487518754011112127;
     const uint64_t FAILURE_PLAN_FAILED_STATE = 3748960977005112327;
     const uint64_t FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE = 4449850763179483831;
 
@@ -161,8 +171,15 @@ TEST_F(AlicaFailureHandlingDisabledMultiAgentFixture, autoFailureHandlingDisable
     ASSERT_TRUE(test::Util::isStateActive(aes[1], FAILURE_PLAN_INIT_STATE));
 
     wm0->setTransitionCondition1446293122737278544(true);
-    wm0->setTransitionCondition1023566846009251524(true);
     wm1->setTransitionCondition1446293122737278544(true);
+    STEP_UNTIL(acs[0], test::Util::isStateActive(aes[0], FAILURE_PLAN_FAIL_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[0], FAILURE_PLAN_FAIL_STATE));
+    STEP_UNTIL(acs[1], test::Util::isStateActive(aes[1], FAILURE_PLAN_FAIL_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[1], FAILURE_PLAN_FAIL_STATE));
+
+    wm0->setTransitionCondition1446293122737278544(false);
+    wm0->setTransitionCondition1023566846009251524(true);
+    wm1->setTransitionCondition1446293122737278544(false);
     wm1->setTransitionCondition1023566846009251524(true);
     STEP_UNTIL(acs[0], test::Util::isStateActive(aes[0], FAILURE_PLAN_FAILED_STATE));
     ASSERT_TRUE(test::Util::isStateActive(aes[0], FAILURE_PLAN_FAILED_STATE));
@@ -184,6 +201,8 @@ TEST_F(AlicaFailureHandlingDisabledMultiAgentFixture, autoFailureHandlingDisable
     ASSERT_TRUE(test::Util::isStateActive(aes[0], FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE));
     STEP_UNTIL(acs[1], test::Util::isStateActive(aes[1], FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE));
     ASSERT_TRUE(test::Util::isStateActive(aes[1], FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE));
+    ASSERT_EQ(wm0->failurePlanInitCallCount(), 1);
+    ASSERT_EQ(wm1->failurePlanInitCallCount(), 1);
 }
 
 } // namespace

--- a/alica_tests/src/test/test_failure_handling.cpp
+++ b/alica_tests/src/test/test_failure_handling.cpp
@@ -11,20 +11,58 @@ class AlicaFailureHandlingEnabledFixture : public AlicaTestFixture
 {
 protected:
     const char* getMasterPlanName() const override { return "FailureHandlingMaster"; }
-    const char* getHostName() const override { return "nase"; }
+    const char* getHostName() const override { return "hairy"; }
+    void SetUp() override
+    {
+        AlicaTestFixture::SetUp();
+        ac->setOption("Alica.AutoFailureHandling", true);
+    }
 };
 
 class AlicaFailureHandlingDisabledFixture : public AlicaTestFixture
 {
 protected:
     const char* getMasterPlanName() const override { return "FailureHandlingMaster"; }
-    const char* getHostName() const override { return "hairy"; }
+    const char* getHostName() const override { return "nase"; }
+    void SetUp() override
+    {
+        AlicaTestFixture::SetUp();
+        ac->setOption("Alica.AutoFailureHandling", false);
+    }
+};
+
+class AlicaFailureHandlingEnabledMultiAgentFixture : public AlicaTestMultiAgentFixture
+{
+protected:
+    const char* getMasterPlanName() const override { return "FailureHandlingMaster"; }
+    virtual int getAgentCount() const { return 2; }
+    const char* getHostName(int agentNumber) const override { return agentNumber ? "nase" : "hairy"; }
+    void SetUp() override
+    {
+        AlicaTestMultiAgentFixture::SetUp();
+        acs[0]->setOption("Alica.AutoFailureHandling", true);
+        acs[1]->setOption("Alica.AutoFailureHandling", true);
+    }
+};
+
+class AlicaFailureHandlingDisabledMultiAgentFixture : public AlicaTestMultiAgentFixture
+{
+protected:
+    const char* getMasterPlanName() const override { return "FailureHandlingMaster"; }
+    virtual int getAgentCount() const { return 2; }
+    const char* getHostName(int agentNumber) const override { return agentNumber ? "nase" : "hairy"; }
+    void SetUp() override
+    {
+        AlicaTestMultiAgentFixture::SetUp();
+        acs[0]->setOption("Alica.AutoFailureHandling", false);
+        acs[1]->setOption("Alica.AutoFailureHandling", false);
+    }
 };
 
 TEST_F(AlicaFailureHandlingEnabledFixture, redoPlanOnFailure)
 {
     // Checks if the FailurePlan is restarted on failure i.e. the redo plan rule should be applied if a plan fails once
-    auto wm = dynamic_cast<alicaTests::TestWorldModel*>(ae->getWorldModel());
+    auto wm = alicaTests::TestWorldModel::getOne();
     const uint64_t FAILURE_PLAN_INIT_STATE = 1171453089016322268;
     const uint64_t FAILURE_PLAN_FAIL_STATE = 3487518754011112127;
 
@@ -41,6 +79,111 @@ TEST_F(AlicaFailureHandlingEnabledFixture, redoPlanOnFailure)
     wm->setTransitionCondition1446293122737278544(false);
     STEP_UNTIL(test::Util::isStateActive(ae, FAILURE_PLAN_INIT_STATE));
     ASSERT_TRUE(test::Util::isStateActive(ae, FAILURE_PLAN_INIT_STATE));
+}
+
+TEST_F(AlicaFailureHandlingDisabledFixture, autoFailureHandlingDisabledTest)
+{
+    // Checks if nothing is done when a plan failure occurs when auto failure handling is disabled
+    auto wm = alicaTests::TestWorldModel::getTwo();
+    const uint64_t FAILURE_PLAN_INIT_STATE = 1171453089016322268;
+    const uint64_t FAILURE_PLAN_FAILED_STATE = 3748960977005112327;
+    const uint64_t FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE = 4449850763179483831;
+
+    ae->start();
+    STEP_UNTIL(test::Util::isStateActive(ae, FAILURE_PLAN_INIT_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(ae, FAILURE_PLAN_INIT_STATE));
+
+    wm->setTransitionCondition1446293122737278544(true);
+    wm->setTransitionCondition1023566846009251524(true);
+    STEP_UNTIL(test::Util::isStateActive(ae, FAILURE_PLAN_FAILED_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(ae, FAILURE_PLAN_FAILED_STATE));
+
+    // Check if we remain in the failed state
+    for (int i = 0; i < 10; ++i) {
+        ac->stepEngine();
+    }
+    ASSERT_TRUE(test::Util::isStateActive(ae, FAILURE_PLAN_FAILED_STATE));
+
+    // Check if higher level plan can check for child failure
+    wm->enableTransitionCondition3194919312481305139();
+    STEP_UNTIL(test::Util::isStateActive(ae, FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(ae, FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE));
+}
+
+TEST_F(AlicaFailureHandlingEnabledMultiAgentFixture, redoPlanOnFailureMultiAgent)
+{
+    // Checks if the FailurePlan is restarted on failure i.e. the redo plan rule should be applied if a plan fails once
+    // The rule should only be applied for the robot that had the failure
+    auto wm0 = alicaTests::TestWorldModel::getOne();
+    auto wm1 = alicaTests::TestWorldModel::getTwo();
+    const uint64_t FAILURE_PLAN_INIT_STATE = 1171453089016322268;
+    const uint64_t FAILURE_PLAN_FAIL_STATE = 3487518754011112127;
+
+    aes[0]->start();
+    aes[1]->start();
+    STEP_UNTIL(acs[0], test::Util::isStateActive(aes[0], FAILURE_PLAN_INIT_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[0], FAILURE_PLAN_INIT_STATE));
+    STEP_UNTIL(acs[1], test::Util::isStateActive(aes[1], FAILURE_PLAN_INIT_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[1], FAILURE_PLAN_INIT_STATE));
+
+    wm0->setTransitionCondition1446293122737278544(true);
+    wm1->setTransitionCondition1446293122737278544(true);
+    STEP_UNTIL(acs[0], test::Util::isStateActive(aes[0], FAILURE_PLAN_FAIL_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[0], FAILURE_PLAN_FAIL_STATE));
+    STEP_UNTIL(acs[1], test::Util::isStateActive(aes[1], FAILURE_PLAN_FAIL_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[1], FAILURE_PLAN_FAIL_STATE));
+
+    // Transition to plan failure state, which will redo the plan for agent 0 & we should end up in the init state again
+    // For agent 1 we should remain in the same state i.e. the plan redo rule should not be applied
+    wm0->setTransitionCondition1023566846009251524(true);
+    wm0->setTransitionCondition1446293122737278544(false);
+    wm1->setTransitionCondition1446293122737278544(false);
+    STEP_UNTIL(acs[0], test::Util::isStateActive(aes[0], FAILURE_PLAN_INIT_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[0], FAILURE_PLAN_INIT_STATE));
+    STEP_UNTIL(acs[1], test::Util::isStateActive(aes[1], FAILURE_PLAN_FAIL_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[1], FAILURE_PLAN_FAIL_STATE));
+}
+
+TEST_F(AlicaFailureHandlingDisabledMultiAgentFixture, autoFailureHandlingDisabledMultiAgentTest)
+{
+    // Checks if nothing is done when a plan failure occurs when auto failure handling is disabled for both agents
+    auto wm0 = alicaTests::TestWorldModel::getOne();
+    auto wm1 = alicaTests::TestWorldModel::getTwo();
+    const uint64_t FAILURE_PLAN_INIT_STATE = 1171453089016322268;
+    const uint64_t FAILURE_PLAN_FAILED_STATE = 3748960977005112327;
+    const uint64_t FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE = 4449850763179483831;
+
+    aes[0]->start();
+    aes[1]->start();
+    STEP_UNTIL(acs[0], test::Util::isStateActive(aes[0], FAILURE_PLAN_INIT_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[0], FAILURE_PLAN_INIT_STATE));
+    STEP_UNTIL(acs[1], test::Util::isStateActive(aes[1], FAILURE_PLAN_INIT_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[1], FAILURE_PLAN_INIT_STATE));
+
+    wm0->setTransitionCondition1446293122737278544(true);
+    wm0->setTransitionCondition1023566846009251524(true);
+    wm1->setTransitionCondition1446293122737278544(true);
+    wm1->setTransitionCondition1023566846009251524(true);
+    STEP_UNTIL(acs[0], test::Util::isStateActive(aes[0], FAILURE_PLAN_FAILED_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[0], FAILURE_PLAN_FAILED_STATE));
+    STEP_UNTIL(acs[1], test::Util::isStateActive(aes[1], FAILURE_PLAN_FAILED_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[1], FAILURE_PLAN_FAILED_STATE));
+
+    // Check if we remain in the failed state
+    for (int i = 0; i < 10; ++i) {
+        acs[0]->stepEngine();
+        acs[1]->stepEngine();
+    }
+    ASSERT_TRUE(test::Util::isStateActive(aes[0], FAILURE_PLAN_FAILED_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[1], FAILURE_PLAN_FAILED_STATE));
+
+    // Check if higher level plan can check for child failure
+    wm0->enableTransitionCondition3194919312481305139();
+    wm1->enableTransitionCondition3194919312481305139();
+    STEP_UNTIL(acs[0], test::Util::isStateActive(aes[0], FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[0], FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE));
+    STEP_UNTIL(acs[1], test::Util::isStateActive(aes[1], FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE));
+    ASSERT_TRUE(test::Util::isStateActive(aes[1], FAILURE_HANDLING_MASTER_FAILURE_HANDLED_STATE));
 }
 
 } // namespace

--- a/supplementary/alica_ros_turtlesim/alica/etc/Alica.yaml
+++ b/supplementary/alica_ros_turtlesim/alica/etc/Alica.yaml
@@ -6,6 +6,9 @@ Alica:
   TeamTimeOut: 2000
   AssignmentProtectionTime: 500
 
+  #Failure Handling
+  AutoFailureHandling: true
+
   #Hz
   MinBroadcastFrequency: 10
   MaxBroadcastFrequency: 15

--- a/supplementary/constraintsolver/test/etc/Alica.yaml
+++ b/supplementary/constraintsolver/test/etc/Alica.yaml
@@ -3,6 +3,9 @@ Alica:
   TeamTimeOut: 30000
   AssignmentProtectionTime: 500
 
+  #Failure Handling
+  AutoFailureHandling: true
+
   #Hz
   MinBroadcastFrequency: 10
   MaxBroadcastFrequency: 15

--- a/supplementary/supplementary_tests/src/test/etc/hairy/Alica.yaml
+++ b/supplementary/supplementary_tests/src/test/etc/hairy/Alica.yaml
@@ -6,6 +6,9 @@ Alica:
   TeamTimeOut: 10000
   AssignmentProtectionTime: 500
 
+  #Failure Handling
+  AutoFailureHandling: true
+
   #Hz
   MinBroadcastFrequency: 10
   MaxBroadcastFrequency: 15

--- a/supplementary/supplementary_tests/src/test/etc/nase/Alica.yaml
+++ b/supplementary/supplementary_tests/src/test/etc/nase/Alica.yaml
@@ -6,6 +6,9 @@ Alica:
   TeamTimeOut: 10000
   AssignmentProtectionTime: 500
 
+  #Failure Handling
+  AutoFailureHandling: true
+
   #Hz
   MinBroadcastFrequency: 10
   MaxBroadcastFrequency: 15


### PR DESCRIPTION
Add a AutoFailureHandling config that can be used to enable/disable
auto failure handling for a plan in the engine