### PR TITLE
Fix scheduler thread wakeups

### DIFF
--- a/alica_engine/include/engine/scheduler/JobQueue.h
+++ b/alica_engine/include/engine/scheduler/JobQueue.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <deque>
-#include <mutex>
 #include <optional>
 
 namespace alica

--- a/alica_engine/include/engine/scheduler/JobQueue.h
+++ b/alica_engine/include/engine/scheduler/JobQueue.h
@@ -15,20 +15,17 @@ class FIFOQueue
 public:
     void push(T&& value)
     {
-        std::lock_guard<std::mutex> lock(_mutex);
         _queue.push_back(std::move(value));
     }
 
     template <class... Args>
     void emplace(Args&&... args)
     {
-        std::lock_guard<std::mutex> lock(_mutex);
         _queue.emplace_back(std::forward<Args>(args)...);
     }
 
     std::optional<T> pop()
     {
-        std::lock_guard<std::mutex> lock(_mutex);
         if (_queue.empty()) {
             return std::nullopt;
         }
@@ -39,14 +36,12 @@ public:
 
     void clear()
     {
-        std::lock_guard<std::mutex> lock(_mutex);
         _queue.clear();
     }
 
     template <class Compare>
     void erase(const T& key, Compare compare)
     {
-        std::lock_guard<std::mutex> lock(_mutex);
         for (auto it = _queue.begin(); it != _queue.end(); ++it) {
             if (compare(key, (*it))) {
                 _queue.erase(it);
@@ -56,11 +51,8 @@ public:
     }
 
 private:
-    std::mutex _mutex;
     std::deque<T> _queue;
 };
-
-// TODO: use a lock free single producer/consumer queue
 
 } // namespace scheduler
 } // namespace alica


### PR DESCRIPTION
It was possible for the scheduler thread to wait on its condition
variable while the condition variable was notified during both
termination & addition of a job to the job queue due to race conditions
resulting from the unlocked manipulation of the running flag & the job
queue. Fix this by grabbing the wait mutex before modifying said
variables.