### PR TITLE
Small Fix in TestContext

### DIFF
--- a/alica_test_utility/src/TestContext.cpp
+++ b/alica_test_utility/src/TestContext.cpp
@@ -27,7 +27,7 @@ int TestContext::init(AlicaCreators& creatorCtx)
 
 int TestContext::init(AlicaCreators&& creatorCtx)
 {
-    return AlicaContext::init(std::move(creatorCtx));
+    return AlicaContext::init(std::move(creatorCtx), true);
 }
 
 void TestContext::startEngine()

--- a/alica_test_utility/src/TestContext.cpp
+++ b/alica_test_utility/src/TestContext.cpp
@@ -32,7 +32,7 @@ int TestContext::init(AlicaCreators&& creatorCtx)
         _communicator->startCommunication();
     }
 
-    if (_engine->init(std::move(creatorCtx))) {
+    if (AlicaContext::init(std::move(creatorCtx))) {
         return 0;
     }
     return -1;

--- a/alica_test_utility/src/TestContext.cpp
+++ b/alica_test_utility/src/TestContext.cpp
@@ -27,15 +27,7 @@ int TestContext::init(AlicaCreators& creatorCtx)
 
 int TestContext::init(AlicaCreators&& creatorCtx)
 {
-    _initCalled = true;
-    if (_communicator) {
-        _communicator->startCommunication();
-    }
-
-    if (AlicaContext::init(std::move(creatorCtx))) {
-        return 0;
-    }
-    return -1;
+    return AlicaContext::init(std::move(creatorCtx));
 }
 
 void TestContext::startEngine()


### PR DESCRIPTION
In `TestContext::init` we call `_engine.init`, which will result in seg fault as `_engine` instance will be null and it only gets created in `AlicaContext::init` so I assume we intend to call `AlicaContext::init` in `TestContext::init` instead of `_engine.init`