### PR TITLE
Allow setting global context to the traces

### DIFF
--- a/alica_engine/include/engine/IAlicaTrace.h
+++ b/alica_engine/include/engine/IAlicaTrace.h
@@ -24,6 +24,8 @@ class IAlicaTraceFactory
 {
 public:
     virtual std::unique_ptr<IAlicaTrace> create(const std::string& opName, std::optional<const std::string> parent = std::nullopt) const = 0;
+    virtual void setGlobalContext(const std::string& globalContext) = 0;
+    virtual void unsetGlobalContext() = 0;
     virtual ~IAlicaTraceFactory() = default;
 };
 

--- a/alica_tests/include/alica_tests/TestTracing.h
+++ b/alica_tests/include/alica_tests/TestTracing.h
@@ -42,6 +42,8 @@ class AlicaTestTraceFactory : public alica::IAlicaTraceFactory
 public:
     AlicaTestTraceFactory(){};
     ~AlicaTestTraceFactory() = default;
+    void setGlobalContext(const std::string& globalContext) override {}
+    void unsetGlobalContext() override {}
 
     std::unique_ptr<alica::IAlicaTrace> create(const std::string& opName, std::optional<const std::string> parent = std::nullopt) const
     {

--- a/supplementary/alica_dummy_tracing/include/alica_dummy_tracing/DummyAlicaTracing.h
+++ b/supplementary/alica_dummy_tracing/include/alica_dummy_tracing/DummyAlicaTracing.h
@@ -26,6 +26,8 @@ class DummyAlicaTestTraceFactory : public alica::IAlicaTraceFactory
 public:
     DummyAlicaTestTraceFactory(){};
     ~DummyAlicaTestTraceFactory() = default;
+    void setGlobalContext(const std::string& globalContext) override {}
+    void unsetGlobalContext() override {}
 
     std::unique_ptr<alica::IAlicaTrace> create(const std::string& opName, std::optional<const std::string> parent = std::nullopt) const
     {

--- a/supplementary/alica_tracing/include/tracing/TraceFactory.h
+++ b/supplementary/alica_tracing/include/tracing/TraceFactory.h
@@ -23,12 +23,16 @@ public:
     TraceFactory&& operator=(TraceFactory&&) = delete;
 
     ~TraceFactory();
-    std::unique_ptr<alica::IAlicaTrace> create(const std::string& opName, std::optional<const std::string> parent = std::nullopt) const;
-
+    std::unique_ptr<alica::IAlicaTrace> create(const std::string& opName, std::optional<const std::string> parent = std::nullopt) const override;
+    virtual void setGlobalContext(const std::string& globalContext) override;
+    virtual void unsetGlobalContext() override;
 private:
     bool _initialized = false;
     std::unordered_map<std::string, RawTraceValue> _defaultTags;
     std::string _serviceName;
+
+    mutable std::mutex _mutex;
+    std::optional<std::string> _globalContext;
 };
 
 } // namespace alicaTracing

--- a/supplementary/alica_tracing/include/tracing/TraceFactory.h
+++ b/supplementary/alica_tracing/include/tracing/TraceFactory.h
@@ -26,6 +26,7 @@ public:
     std::unique_ptr<alica::IAlicaTrace> create(const std::string& opName, std::optional<const std::string> parent = std::nullopt) const override;
     void setGlobalContext(const std::string& globalContext) override;
     void unsetGlobalContext() override;
+
 private:
     bool _initialized = false;
     std::unordered_map<std::string, RawTraceValue> _defaultTags;

--- a/supplementary/alica_tracing/include/tracing/TraceFactory.h
+++ b/supplementary/alica_tracing/include/tracing/TraceFactory.h
@@ -24,8 +24,8 @@ public:
 
     ~TraceFactory();
     std::unique_ptr<alica::IAlicaTrace> create(const std::string& opName, std::optional<const std::string> parent = std::nullopt) const override;
-    virtual void setGlobalContext(const std::string& globalContext) override;
-    virtual void unsetGlobalContext() override;
+    void setGlobalContext(const std::string& globalContext) override;
+    void unsetGlobalContext() override;
 private:
     bool _initialized = false;
     std::unordered_map<std::string, RawTraceValue> _defaultTags;

--- a/supplementary/alica_tracing/src/tracing/TraceFactory.cpp
+++ b/supplementary/alica_tracing/src/tracing/TraceFactory.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<alica::IAlicaTrace> TraceFactory::create(const std::string& opNa
     std::optional<std::string> applicableParent = parent;
     if(!applicableParent) {
         std::lock_guard<std::mutex> lck(_mutex);
-        applicableParent = _globalContext;    // Note: _currentGlobalContext can expectedly be empty
+        applicableParent = _globalContext;    // Note: _globalContext may be intentionally empty
     }
 
     std::unique_ptr<Trace> trace = std::make_unique<Trace>(opName, applicableParent);

--- a/supplementary/alica_tracing/src/tracing/TraceFactory.cpp
+++ b/supplementary/alica_tracing/src/tracing/TraceFactory.cpp
@@ -42,7 +42,13 @@ std::unique_ptr<alica::IAlicaTrace> TraceFactory::create(const std::string& opNa
         return std::make_unique<Trace>();
     }
 
-    std::unique_ptr<Trace> trace = std::make_unique<Trace>(opName, parent);
+    std::optional<std::string> applicableParent = parent;
+    if(!applicableParent) {
+        std::lock_guard<std::mutex> lck(_mutex);
+        applicableParent = _globalContext;    // Note: _currentGlobalContext can expectedly be empty
+    }
+
+    std::unique_ptr<Trace> trace = std::make_unique<Trace>(opName, applicableParent);
     for (const auto& defaultTag : _defaultTags) {
         trace->setTag(defaultTag.first, defaultTag.second);
     }
@@ -50,4 +56,15 @@ std::unique_ptr<alica::IAlicaTrace> TraceFactory::create(const std::string& opNa
     return trace;
 }
 
+void TraceFactory::setGlobalContext(const std::string& globalContext)
+{
+    std::lock_guard<std::mutex> lck(_mutex);
+    _globalContext = globalContext;
+}
+
+void TraceFactory::unsetGlobalContext()
+{
+    std::lock_guard<std::mutex> lck(_mutex);
+    _globalContext.reset();
+}
 } // namespace alicaTracing

--- a/supplementary/alica_tracing/src/tracing/TraceFactory.cpp
+++ b/supplementary/alica_tracing/src/tracing/TraceFactory.cpp
@@ -43,9 +43,9 @@ std::unique_ptr<alica::IAlicaTrace> TraceFactory::create(const std::string& opNa
     }
 
     std::optional<std::string> applicableParent = parent;
-    if(!applicableParent) {
+    if (!applicableParent) {
         std::lock_guard<std::mutex> lck(_mutex);
-        applicableParent = _globalContext;    // Note: _currentGlobalContext can expectedly be empty
+        applicableParent = _globalContext; // Note: _currentGlobalContext can expectedly be empty
     }
 
     std::unique_ptr<Trace> trace = std::make_unique<Trace>(opName, applicableParent);

--- a/supplementary/alica_tracing/src/tracing/TraceFactory.cpp
+++ b/supplementary/alica_tracing/src/tracing/TraceFactory.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<alica::IAlicaTrace> TraceFactory::create(const std::string& opNa
     std::optional<std::string> applicableParent = parent;
     if (!applicableParent) {
         std::lock_guard<std::mutex> lck(_mutex);
-        applicableParent = _globalContext;    // Note: _globalContext may be intentionally empty
+        applicableParent = _globalContext; // Note: _globalContext may be intentionally empty
     }
 
     std::unique_ptr<Trace> trace = std::make_unique<Trace>(opName, applicableParent);


### PR DESCRIPTION
This will allow all robot traces without a parent to be reported under a global context that robot is working on currently, example a task from a central controlling node.