### PR TITLE
Added test compilation logic

### DIFF
--- a/alica_solver_interface/CMakeLists.txt
+++ b/alica_solver_interface/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(alica_solver_interface)
-
+include(CTest)
 ## Change to use clang ... unfortunately it doesnt work :(
 #set(CMAKE_CXX_COMPILER "clang")
 #
@@ -38,9 +38,11 @@ target_link_libraries(alica_solver_interface PUBLIC)
 
 
 # Testing Setup
+if(BUILD_TESTING)
+
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
-include(CTest)
+
 find_package(Threads REQUIRED)
 find_package(GTest REQUIRED)
   include_directories(BEFORE
@@ -57,6 +59,7 @@ target_link_libraries(${PROJECT_NAME}-tests PRIVATE Threads::Threads ${PROJECT_N
 add_test(NAME IntervalTest.Double COMMAND ${PROJECT_NAME}-tests --gtest_filter=IntervalTest.Double )
 add_test(NAME IntervalTest.Operations COMMAND ${PROJECT_NAME}-tests --gtest_filter=IntervalTest.Operations )
 
+endif()
 
 install(TARGETS ${PROJECT_NAME}
   EXPORT ${CMAKE_PROJECT_NAME}Targets

--- a/alica_tests/CMakeLists.txt
+++ b/alica_tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(alica_tests)
+include(CTest)
 
 add_compile_options(-std=c++17)
 set(CMAKE_BUILD_TYPE Debug)
@@ -31,7 +32,7 @@ file(GLOB_RECURSE autogen_SOURCES "src/test/Expr/src/*.cpp")
 add_library(autogen_code_alica_tests ${autogen_SOURCES})
 target_link_libraries(autogen_code_alica_tests ${catkin_LIBRARIES} alica_test_utility alica_dummy_proxy)
 
-if(CATKIN_ENABLE_TESTING)
+if(BUILD_TESTING)
     find_package(rostest REQUIRED)
 
     set(test_alica_SOURCES

--- a/supplementary/alica_ros_proxy/CMakeLists.txt
+++ b/supplementary/alica_ros_proxy/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(alica_ros_proxy)
+include(CTest)
 
 add_compile_options(-std=c++17)
 include(../../cmake_flags/cflags.cmake)
@@ -52,7 +53,7 @@ install(DIRECTORY include/
   PATTERN ".svn" EXCLUDE
 )
 
-if(CATKIN_ENABLE_TESTING)
+if(BUILD_TESTING)
   find_package(catkin REQUIRED COMPONENTS
     rostest
     roscpp

--- a/supplementary/autodiff/CMakeLists.txt
+++ b/supplementary/autodiff/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(autodiff)
+include(CTest)
 
 if (${CMAKE_EXTRA_GENERATOR} MATCHES "Eclipse CDT4")
 	set(CMAKE_CXX_COMPILER_ARG1 "-std=c++14" CACHE STRING "C++ version for eclipse" FORCE)
@@ -70,13 +71,15 @@ target_link_libraries(sine_benchmark ${PROJECT_NAME} alica_solver_interface)
 
 
 # AUTODIFF TESTS
+if(BUILD_TESTING)
+
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 find_package(Threads REQUIRED)
 
 find_package(GTest REQUIRED)
 
-include(CTest)
+
 
 include_directories(BEFORE
   ${GTEST_INCLUDE_DIRS}
@@ -107,6 +110,7 @@ add_test(NAME AutoDiffTest.TERMPOWER COMMAND ${PROJECT_NAME}-tests [==[--gtest_f
 add_test(NAME AutoDiffTest.EQUALITY COMMAND ${PROJECT_NAME}-tests [==[--gtest_filter=AutoDiffTest.EQUALITY]==] )
 add_test(NAME AutoDiffTest.COMPILED COMMAND ${PROJECT_NAME}-tests [==[--gtest_filter=AutoDiffTest.COMPILED]==] )
 
+endif()
 
 # Install
 install(TARGETS ${PROJECT_NAME}

--- a/supplementary/constraintsolver/CMakeLists.txt
+++ b/supplementary/constraintsolver/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(constraintsolver)
+include(CTest)
 
 add_compile_options(-std=c++17)
 
@@ -58,9 +59,10 @@ target_include_directories(constraintsolver PUBLIC
 
 target_link_libraries(constraintsolver PUBLIC autodiff alica_engine ${YAML_CPP_LIBRARIES})
 
+if(BUILD_TESTING)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
-include(CTest)
+
 find_package(Threads REQUIRED)
 find_package(GTest REQUIRED)
   include_directories(BEFORE
@@ -89,6 +91,7 @@ add_test(NAME CNSatTest.CNSAT1dubois22 COMMAND ${PROJECT_NAME}-tests --gtest_fil
 add_test(NAME CNSatTest.CNSAThole6 COMMAND ${PROJECT_NAME}-tests --gtest_filter=CNSatTest.CNSAThole6 )
 add_test(NAME CNSatTest.CNSAT1_dubois20 COMMAND ${PROJECT_NAME}-tests --gtest_filter=CNSatTest.CNSAT1_dubois20 )
 
+endif()
 
 install(TARGETS ${PROJECT_NAME}
   EXPORT ${CMAKE_PROJECT_NAME}Targets

--- a/supplementary/supplementary_tests/CMakeLists.txt
+++ b/supplementary/supplementary_tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(supplementary_tests)
+include(CTest)
 
 add_compile_options(-std=c++17)
 
@@ -36,7 +37,7 @@ file(GLOB_RECURSE autogen_SOURCES "src/test/Expr/src/*.cpp")
 add_library(autogen_code_supplementary_tests ${autogen_SOURCES};)
 target_link_libraries(autogen_code_supplementary_tests ${catkin_LIBRARIES} alica_test_utility constraintsolver)
 
-if (CATKIN_ENABLE_TESTING)
+if (BUILD_TESTING)
 
     find_package(rostest REQUIRED)
     set(test_supplementary_SOURCES


### PR DESCRIPTION
Put all tests behind BUILD_TESTING cmake flag. Use -DBUILD_TESTING=OFF as a CMake argument to disable the building of tests.