### PR TITLE
Minor CMake bug in alica_tracing

### DIFF
--- a/supplementary/alica_tracing/CMakeLists.txt
+++ b/supplementary/alica_tracing/CMakeLists.txt
@@ -26,7 +26,7 @@ include_directories(
 
 # Declare a C++ library with project namespace to avoid naming collision
 add_library(
-  ${PROJECT_NAME}
+  ${PROJECT_NAME} SHARED
   src/tracing/Trace.cpp
   src/tracing/TraceFactory.cpp
 )


### PR DESCRIPTION
The alica tracing library was not being exported as a shared object, resulting in some compiler warnings when linking against it