### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/ros1_build_test/Dockerfile
+++ b/.github/workflows/ros1_build_test/Dockerfile
@@ -9,17 +9,21 @@ COPY . .
 
 WORKDIR /root/catkin_ws/
 
-RUN apt-get update && \
-    apt-get install -y python3-catkin-tools libboost-all-dev && \
-    rosdep install -y --from-paths . --ignore-src --skip-keys='rclcpp ament_cmake' --rosdistro noetic
+RUN <<deps
+  apt-get update || exit 1
+  apt-get install -y python3-catkin-tools libboost-all-dev || exit 1
+  rosdep install -y --from-paths . --ignore-src --skip-keys='rclcpp ament_cmake' --rosdistro noetic
+deps
 
+RUN <<build
+  source /opt/ros/noetic/setup.bash || exit 1
+  catkin init || exit 1
+  catkin config --install --skiplist alica_tracing alica_ros2_proxy alica_ros2_turtlesim || exit 1
+  catkin build --no-status
+build
 
-RUN source /opt/ros/noetic/setup.bash && \
-    catkin init && \
-    catkin config --install --skiplist alica_tracing alica_ros2_proxy alica_ros2_turtlesim && \
-    catkin build --no-status
-
-
-RUN source devel/setup.bash && \
-    catkin run_tests --no-status && \
-    catkin_test_results --verbose
+RUN <<runtests
+  source devel/setup.bash || exit 1
+  catkin run_tests --no-status || exit 1
+  catkin_test_results --verbose
+runtests

--- a/.github/workflows/ros1_build_test/Dockerfile
+++ b/.github/workflows/ros1_build_test/Dockerfile
@@ -16,14 +16,14 @@ RUN <<deps
 deps
 
 RUN <<build
-  source /opt/ros/noetic/setup.bash || exit 1
+  source /opt/ros/noetic/setup.bash
   catkin init || exit 1
   catkin config --install --skiplist alica_tracing alica_ros2_proxy alica_ros2_turtlesim || exit 1
   catkin build --no-status
 build
 
 RUN <<runtests
-  source devel/setup.bash || exit 1
+  source devel/setup.bash
   catkin run_tests --no-status || exit 1
   catkin_test_results --verbose
 runtests

--- a/.github/workflows/ros1_build_test/Dockerfile
+++ b/.github/workflows/ros1_build_test/Dockerfile
@@ -9,21 +9,17 @@ COPY . .
 
 WORKDIR /root/catkin_ws/
 
-RUN <<deps
-  apt-get update
-  apt-get install -y python3-catkin-tools libboost-all-dev
-  rosdep install -y --from-paths . --ignore-src --skip-keys='rclcpp ament_cmake' --rosdistro noetic
-deps
+RUN apt-get update && \
+    apt-get install -y python3-catkin-tools libboost-all-dev && \
+    rosdep install -y --from-paths . --ignore-src --skip-keys='rclcpp ament_cmake' --rosdistro noetic
 
-RUN <<build
-  source /opt/ros/noetic/setup.bash
-  catkin init
-  catkin config --install --skiplist alica_tracing alica_ros2_proxy alica_ros2_turtlesim
-  catkin build --no-status
-build
 
-RUN <<runtests
-  source devel/setup.bash
-  catkin run_tests --no-status
-  catkin_test_results --verbose build/test_results
-runtests
+RUN source /opt/ros/noetic/setup.bash && \
+    catkin init && \
+    catkin config --install --skiplist alica_tracing alica_ros2_proxy alica_ros2_turtlesim && \
+    catkin build --no-status
+
+
+RUN source devel/setup.bash && \
+    catkin run_tests --no-status && \
+    catkin_test_results --verbose

--- a/.github/workflows/ros1_build_test/Dockerfile
+++ b/.github/workflows/ros1_build_test/Dockerfile
@@ -25,5 +25,5 @@ build
 RUN <<runtests
   source devel/setup.bash
   catkin run_tests --no-status
-  catkin_test_results --verbose
+  catkin_test_results --verbose build/test_results
 runtests

--- a/.github/workflows/ros2_build_test/Dockerfile
+++ b/.github/workflows/ros2_build_test/Dockerfile
@@ -8,13 +8,17 @@ WORKDIR /root/ws/src
 
 COPY . src
 
-RUN apt-get update && \
-    apt-get install -y libboost-all-dev && \
-    source /opt/ros/humble/setup.bash && \
-    rosdep update && \
-    rosdep install -y -r --from-paths . --ignore-src --rosdistro humble
+RUN <<deps
+  apt-get update || exit 1
+  apt-get install -y libboost-all-dev || exit 1
+  source /opt/ros/humble/setup.bash || exit 1
+  rosdep update || exit 1
+  rosdep install -y -r --from-paths . --ignore-src --rosdistro humble
+deps
 
 
 
-RUN source /opt/ros/humble/setup.bash && \
-    colcon build --continue-on-error --packages-skip alica_ros_proxy alica_tracing alica_ros_turtlesim alica_tests supplementary_tests
+RUN <<build
+  source /opt/ros/humble/setup.bash || exit 1
+  colcon build --continue-on-error --packages-skip alica_ros_proxy alica_tracing alica_ros_turtlesim alica_tests supplementary_tests
+build

--- a/.github/workflows/ros2_build_test/Dockerfile
+++ b/.github/workflows/ros2_build_test/Dockerfile
@@ -11,7 +11,7 @@ COPY . src
 RUN <<deps
   apt-get update || exit 1
   apt-get install -y libboost-all-dev || exit 1
-  source /opt/ros/humble/setup.bash || exit 1
+  source /opt/ros/humble/setup.bash
   rosdep update || exit 1
   rosdep install -y -r --from-paths . --ignore-src --rosdistro humble
 deps
@@ -19,6 +19,6 @@ deps
 
 
 RUN <<build
-  source /opt/ros/humble/setup.bash || exit 1
+  source /opt/ros/humble/setup.bash
   colcon build --continue-on-error --packages-skip alica_ros_proxy alica_tracing alica_ros_turtlesim alica_tests supplementary_tests
 build

--- a/.github/workflows/ros2_build_test/Dockerfile
+++ b/.github/workflows/ros2_build_test/Dockerfile
@@ -8,17 +8,13 @@ WORKDIR /root/ws/src
 
 COPY . src
 
-RUN <<deps
-  apt-get update
-  apt-get install -y libboost-all-dev
-  source /opt/ros/humble/setup.bash
-  rosdep update
-  rosdep install -y -r --from-paths . --ignore-src --rosdistro humble
-deps
+RUN apt-get update && \
+    apt-get install -y libboost-all-dev && \
+    source /opt/ros/humble/setup.bash && \
+    rosdep update && \
+    rosdep install -y -r --from-paths . --ignore-src --rosdistro humble
 
 
 
-RUN <<build
-  source /opt/ros/humble/setup.bash
-  colcon build --continue-on-error --packages-skip alica_ros_proxy alica_tracing alica_ros_turtlesim alica_tests supplementary_tests
-build
+RUN source /opt/ros/humble/setup.bash && \
+    colcon build --continue-on-error --packages-skip alica_ros_proxy alica_tracing alica_ros_turtlesim alica_tests supplementary_tests

--- a/supplementary/alica_ros1/alica_tests/src/test/test_alica_tracing.cpp
+++ b/supplementary/alica_ros1/alica_tests/src/test/test_alica_tracing.cpp
@@ -141,7 +141,7 @@ TEST_F(AlicaAuthorityTracingTest, taskAssignmentTracing)
     }
     EXPECT_TRUE(foundTaskAssignmentChangeLog);
     EXPECT_EQ(twm1->tracingParents["EmptyBehaviour"], "AuthorityTest");
-    EXPECT_EQ(twm2->tracingParents["EmptyBehaviour"], "AuthorityTest"); // added by Luca
+    EXPECT_NE(twm2->tracingParents["EmptyBehaviour"], "AuthorityTest"); // added by Luca
 }
 
 } // namespace

--- a/supplementary/alica_ros1/alica_tests/src/test/test_alica_tracing.cpp
+++ b/supplementary/alica_ros1/alica_tests/src/test/test_alica_tracing.cpp
@@ -141,7 +141,7 @@ TEST_F(AlicaAuthorityTracingTest, taskAssignmentTracing)
     }
     EXPECT_TRUE(foundTaskAssignmentChangeLog);
     EXPECT_EQ(twm1->tracingParents["EmptyBehaviour"], "AuthorityTest");
-    EXPECT_NE(twm2->tracingParents["EmptyBehaviour"], "AuthorityTest"); // added by Luca
+    EXPECT_EQ(twm2->tracingParents["EmptyBehaviour"], "AuthorityTest"); // added by Luca
 }
 
 } // namespace


### PR DESCRIPTION
Chaining commands using << syntax results in incorrect behaviour since only the exit status of the last command is taken into account & the build succeeds even if some intermediate command fails