### PR TITLE
make Blackboard class virtual

### DIFF
--- a/alica_engine/include/engine/blackboard/Blackboard.h
+++ b/alica_engine/include/engine/blackboard/Blackboard.h
@@ -350,6 +350,8 @@ public:
     BlackboardImpl& impl() { return _impl; }
     const BlackboardImpl& impl() const { return _impl; }
 
+    virtual ~Blackboard() = default;
+
 private:
     BlackboardImpl _impl;
     mutable std::shared_mutex _mtx;


### PR DESCRIPTION
To avoid _source type is not polymorphic_ problems with dynamic_cast, we should make Blackboard virtual