### PR TITLE
Fix SyncStopTimerRosImpl member init order

### DIFF
--- a/supplementary/alica_ros1/alica_ros_proxy/include/clock/AlicaRosTimer.h
+++ b/supplementary/alica_ros1/alica_ros_proxy/include/clock/AlicaRosTimer.h
@@ -30,8 +30,8 @@ public:
             , _timer()
             , _stopMutex()
             , _stopCv()
-            , _userCbInProgress(false)
             , _stop(false)
+            , _userCbInProgress(false)
     {
         _nh.setCallbackQueue(std::addressof(cbQ));
     }


### PR DESCRIPTION
The init list order doesn't match the definition order.

One of the warnings to be fixed for https://www.wrike.com/open.htm?id=1022023867 .