### PR TITLE
Fix problems spotted by clang

### DIFF
--- a/alica_engine/include/engine/IAlicaCommunication.h
+++ b/alica_engine/include/engine/IAlicaCommunication.h
@@ -17,7 +17,7 @@ struct SyncReady;
 struct SyncReady;
 struct AgentQuery;
 struct AgentAnnouncement;
-class RoleSwitch;
+struct RoleSwitch;
 
 struct AlicaCommunicationHandlers
 {

--- a/alica_engine/include/engine/IBehaviourCreator.h
+++ b/alica_engine/include/engine/IBehaviourCreator.h
@@ -5,7 +5,7 @@
 namespace alica
 {
 class BasicBehaviour;
-class BehaviourContext;
+struct BehaviourContext;
 
 class IBehaviourCreator
 {

--- a/alica_engine/include/engine/IConditionCreator.h
+++ b/alica_engine/include/engine/IConditionCreator.h
@@ -11,7 +11,7 @@
 namespace alica
 {
 class BasicCondition;
-class ConditionContext;
+struct ConditionContext;
 
 class IConditionCreator
 {

--- a/alica_engine/include/engine/IPlanCreator.h
+++ b/alica_engine/include/engine/IPlanCreator.h
@@ -6,7 +6,7 @@ namespace alica
 {
 
 class BasicPlan;
-class PlanContext;
+struct PlanContext;
 
 class IPlanCreator
 {

--- a/alica_engine/include/engine/ITransitionConditionCreator.h
+++ b/alica_engine/include/engine/ITransitionConditionCreator.h
@@ -6,7 +6,7 @@ namespace alica
 {
 class RunningPlan;
 class Blackboard;
-class TransitionConditionContext;
+struct TransitionConditionContext;
 
 class ITransitionConditionCreator
 {

--- a/alica_engine/include/engine/Output.h
+++ b/alica_engine/include/engine/Output.h
@@ -4,19 +4,25 @@
 
 #include <iterator>
 #include <ostream>
+#include <type_traits>
 
 namespace alica
 {
 
-inline std::ostream& operator<<(std::ostream& out, const AgentGrp& ag)
+template <typename T, std::enable_if_t<std::is_pointer<T>::value, bool> = true>
+std::ostream& operator<<(std::ostream& out, const std::vector<T>& gr)
 {
-    std::copy(ag.begin(), ag.end(), std::ostream_iterator<AgentId>(out, " "));
+    for (const auto* const v : gr) {
+        out << *v << " ";
+    }
     return out;
 }
 
-inline std::ostream& operator<<(std::ostream& out, const IdGrp& ig)
+template <typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+std::ostream& operator<<(std::ostream& out, const std::vector<T>& gr)
 {
-    std::copy(ig.begin(), ig.end(), std::ostream_iterator<int64_t>(out, " "));
+    std::copy(gr.begin(), gr.end(), std::ostream_iterator<T>(out, " "));
     return out;
 }
+
 } // namespace alica

--- a/alica_engine/include/engine/Output.h
+++ b/alica_engine/include/engine/Output.h
@@ -13,7 +13,11 @@ template <typename T, std::enable_if_t<std::is_pointer<T>::value, bool> = true>
 std::ostream& operator<<(std::ostream& out, const std::vector<T>& gr)
 {
     for (const auto* const v : gr) {
-        out << *v << " ";
+        if (v) {
+            out << *v << " ";
+        } else {
+            out << "*nullptr* ";
+        }
     }
     return out;
 }

--- a/alica_engine/include/engine/TeamObserver.h
+++ b/alica_engine/include/engine/TeamObserver.h
@@ -15,7 +15,7 @@ class Logger;
 class SuccessCollection;
 class TeamManager;
 class Agent;
-class PlanTreeInfo;
+struct PlanTreeInfo;
 class RunningPlan;
 class SimplePlanTree;
 class IRoleAssignment;

--- a/alica_engine/include/engine/collections/RobotProperties.h
+++ b/alica_engine/include/engine/collections/RobotProperties.h
@@ -17,7 +17,7 @@ struct AgentAnnouncement;
 class RobotProperties
 {
 public:
-    RobotProperties(const PlanRepository& planRepository, const std::string& defaultRole, const AgentAnnouncement& aa);
+    RobotProperties(const PlanRepository&, const std::string& defaultRole, const AgentAnnouncement& aa);
     ~RobotProperties();
 
     const std::string& getDefaultRole() const { return _defaultRole; }
@@ -30,7 +30,6 @@ public:
 
 private:
     std::string _defaultRole;
-    const PlanRepository& _planRepository;
 };
 
 } /* namespace alica */

--- a/alica_engine/include/engine/collections/RobotProperties.h
+++ b/alica_engine/include/engine/collections/RobotProperties.h
@@ -17,8 +17,8 @@ struct AgentAnnouncement;
 class RobotProperties
 {
 public:
-    RobotProperties(const PlanRepository&, const std::string& defaultRole, const AgentAnnouncement& aa);
-    ~RobotProperties();
+    RobotProperties(const std::string& defaultRole, const AgentAnnouncement& aa);
+    ~RobotProperties() = default;
 
     const std::string& getDefaultRole() const { return _defaultRole; }
 

--- a/alica_engine/include/engine/expressionhandler/ExpressionHandler.h
+++ b/alica_engine/include/engine/expressionhandler/ExpressionHandler.h
@@ -6,7 +6,7 @@ class RunningPlan;
 class Plan;
 class Condition;
 class PlanRepository;
-class AlicaCreators;
+struct AlicaCreators;
 class IConstraintCreator;
 
 /**

--- a/alica_engine/include/engine/logging/Logging.h
+++ b/alica_engine/include/engine/logging/Logging.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "engine/Output.h"
 #include "engine/logging/AlicaLogger.h"
 namespace alica
 {

--- a/alica_engine/include/engine/syncmodule/SynchronisationProcess.h
+++ b/alica_engine/include/engine/syncmodule/SynchronisationProcess.h
@@ -46,14 +46,12 @@ private:
     SyncModule* _syncModule;
     const Synchronisation* _synchronisation;
     AgentId _myID;
-    SyncData* _lastTalkData;
     AlicaTime _lastTalkTime;
     AlicaTime _syncStartTime;
     bool _readyForSync;
     uint64_t _lastTick;
     std::vector<std::shared_ptr<SyncReady>> _receivedSyncReadys;
     std::vector<int64_t> _connectedTransitions;
-    RunningPlan* _runningPlan;
     std::vector<SyncRow*> _rowsOK;
     std::vector<SyncRow*> _syncMatrix;
     SyncRow* _myRow;

--- a/alica_engine/src/engine/collections/RobotProperties.cpp
+++ b/alica_engine/src/engine/collections/RobotProperties.cpp
@@ -5,7 +5,7 @@
 namespace alica
 {
 
-RobotProperties::RobotProperties(const PlanRepository&, const std::string& defaultRole, const AgentAnnouncement& aa)
+RobotProperties::RobotProperties(const std::string& defaultRole, const AgentAnnouncement& aa)
         : _defaultRole(defaultRole.empty() ? "NOROLESPECIFIED" : defaultRole)
 {
     // TODO: develop proper Role-Capability-Stuff when we need it
@@ -22,7 +22,5 @@ RobotProperties::RobotProperties(const PlanRepository&, const std::string& defau
     //        }
     //    }
 }
-
-RobotProperties::~RobotProperties() {}
 
 } /* namespace alica */

--- a/alica_engine/src/engine/collections/RobotProperties.cpp
+++ b/alica_engine/src/engine/collections/RobotProperties.cpp
@@ -5,9 +5,8 @@
 namespace alica
 {
 
-RobotProperties::RobotProperties(const PlanRepository& planRepository, const std::string& defaultRole, const AgentAnnouncement& aa)
-        : _planRepository(planRepository)
-        , _defaultRole(defaultRole.empty() ? "NOROLESPECIFIED" : defaultRole)
+RobotProperties::RobotProperties(const PlanRepository&, const std::string& defaultRole, const AgentAnnouncement& aa)
+        : _defaultRole(defaultRole.empty() ? "NOROLESPECIFIED" : defaultRole)
 {
     // TODO: develop proper Role-Capability-Stuff when we need it
     //    for (const AgentAnnouncement::CapabilityPair& cp : aa.capabilities) {

--- a/alica_engine/src/engine/constraintmodul/ConditionStore.cpp
+++ b/alica_engine/src/engine/constraintmodul/ConditionStore.cpp
@@ -14,16 +14,6 @@
 
 namespace alica
 {
-namespace
-{
-std::ostream& operator<<(std::ostream& out, const VariableGrp& vg)
-{
-    for (const Variable* v : vg) {
-        out << v->getName() << "(" << v->getId() << "), ";
-    }
-    return out;
-}
-} // namespace
 /**
  * Default constructor
  */

--- a/alica_engine/src/engine/constraintmodul/VariableSyncModule.cpp
+++ b/alica_engine/src/engine/constraintmodul/VariableSyncModule.cpp
@@ -70,7 +70,7 @@ void VariableSyncModule::reload(const YAML::Node& config)
         double communicationFrequency = config["Alica"]["CSPSolving"]["CommunicationFrequency"].as<double>();
         AlicaTime interval = AlicaTime::seconds(1.0 / communicationFrequency);
         if (_timer == nullptr) {
-            _timer = _timerFactory.createTimer(std::move(std::bind(&VariableSyncModule::publishContent, this)), interval);
+            _timer = _timerFactory.createTimer(std::bind(&VariableSyncModule::publishContent, this), interval);
         }
     }
 }

--- a/alica_engine/src/engine/modelmanagement/factories/BehaviourFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/BehaviourFactory.cpp
@@ -36,9 +36,9 @@ Behaviour* BehaviourFactory::create(const YAML::Node& node)
     auto inheritBlackboard = Factory::getValue<bool>(node, alica::Strings::inheritBlackboard, true);
     if (!inheritBlackboard) {
         if (Factory::isValid(node[alica::Strings::blackboard])) {
-            behaviour->_blackboardBlueprint = std::move(BlackboardBlueprintFactory::create(node[alica::Strings::blackboard]));
+            behaviour->_blackboardBlueprint = BlackboardBlueprintFactory::create(node[alica::Strings::blackboard]);
         } else {
-            behaviour->_blackboardBlueprint = std::move(BlackboardBlueprintFactory::createEmpty());
+            behaviour->_blackboardBlueprint = BlackboardBlueprintFactory::createEmpty();
         }
     } else {
         behaviour->_blackboardBlueprint = nullptr;

--- a/alica_engine/src/engine/modelmanagement/factories/PlanFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/PlanFactory.cpp
@@ -106,9 +106,9 @@ Plan* PlanFactory::create(ConfigChangeListener& configChangeListener, const YAML
 
     if (!inheritBlackboard) {
         if (Factory::isValid(node[alica::Strings::blackboard])) {
-            plan->_blackboardBlueprint = std::move(BlackboardBlueprintFactory::create(node[alica::Strings::blackboard]));
+            plan->_blackboardBlueprint = BlackboardBlueprintFactory::create(node[alica::Strings::blackboard]);
         } else {
-            plan->_blackboardBlueprint = std::move(BlackboardBlueprintFactory::createEmpty());
+            plan->_blackboardBlueprint = BlackboardBlueprintFactory::createEmpty();
         }
     } else {
         plan->_blackboardBlueprint = nullptr;

--- a/alica_engine/src/engine/modelmanagement/factories/QuantifierFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/QuantifierFactory.cpp
@@ -7,7 +7,7 @@ namespace alica
 {
 Quantifier* QuantifierFactory::create(const YAML::Node& quantifierNode)
 {
-    Quantifier* quantifier;
+    Quantifier* quantifier = nullptr;
     std::string quantifierType;
     if (Factory::isValid(quantifierNode[alica::Strings::quantifierType])) {
         quantifierType = Factory::getValue<std::string>(quantifierNode, alica::Strings::quantifierType);

--- a/alica_engine/src/engine/modelmanagement/factories/TransitionConditionFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/TransitionConditionFactory.cpp
@@ -13,9 +13,9 @@ TransitionCondition* TransitionConditionFactory::create(const YAML::Node& condit
 {
     std::unique_ptr<BlackboardBlueprint> blackboardBlueprint;
     if (Factory::isValid(conditionNode[alica::Strings::blackboard])) {
-        blackboardBlueprint = std::move(BlackboardBlueprintFactory::create(conditionNode[alica::Strings::blackboard]));
+        blackboardBlueprint = BlackboardBlueprintFactory::create(conditionNode[alica::Strings::blackboard]);
     } else {
-        blackboardBlueprint = std::move(BlackboardBlueprintFactory::createEmpty());
+        blackboardBlueprint = BlackboardBlueprintFactory::createEmpty();
     }
     TransitionCondition* transitionCondition = new TransitionCondition(std::move(blackboardBlueprint));
     Factory::setAttributes(conditionNode, transitionCondition);

--- a/alica_engine/src/engine/planselector/TaskAssignmentProblem.cpp
+++ b/alica_engine/src/engine/planselector/TaskAssignmentProblem.cpp
@@ -72,7 +72,6 @@ void TaskAssignmentProblem::preassignOtherAgents()
     // this call should only be made before the search starts
     assert(_fringe.size() == _plans.size());
     // ASSIGN PREASSIGNED OTHER ROBOTS
-    int i = 0;
     bool changed = false;
     for (PartialAssignment* curPa : _fringe) {
         if (addAlreadyAssignedRobots(curPa, simplePlanTreeMap)) {
@@ -80,7 +79,6 @@ void TaskAssignmentProblem::preassignOtherAgents()
             curPa->evaluate(nullptr, _globalBlackboard);
             changed = true;
         }
-        ++i;
     }
     if (changed) {
         stable_sort(_fringe.begin(), _fringe.end(), PartialAssignment::compare);

--- a/alica_engine/src/engine/syncmodule/SynchronisationProcess.cpp
+++ b/alica_engine/src/engine/syncmodule/SynchronisationProcess.cpp
@@ -22,9 +22,7 @@ SynchronisationProcess::SynchronisationProcess(const AlicaClock& clock, AgentId 
         , _syncModule(sm)
         , _readyForSync(false)
         , _lastTick(0)
-        , _runningPlan(nullptr)
         , _myRow(nullptr)
-        , _lastTalkData(nullptr)
         , _synchronisationDone(false)
         , _clock(clock)
 {

--- a/alica_engine/src/engine/teammanager/Agent.cpp
+++ b/alica_engine/src/engine/teammanager/Agent.cpp
@@ -18,7 +18,7 @@ Agent::Agent(const ModelManager& modelManager, const PlanRepository& planReposit
         , _planHash(aa.planHash)
         , _sdk(aa.senderSdk)
         , _clock(clock)
-        , _properties(planRepository, defaultRole, aa)
+        , _properties(defaultRole, aa)
         , _engineData(modelManager, planRepository, aa.senderID)
         , _timeout(timeout)
         , _active(false)

--- a/alica_engine/src/engine/teammanager/TeamManager.cpp
+++ b/alica_engine/src/engine/teammanager/TeamManager.cpp
@@ -18,12 +18,6 @@
 
 namespace alica
 {
-
-namespace
-{
-constexpr int DEFAULT_AGENT_ID_SIZE = 8;
-}
-
 AgentsCache::AgentsCache()
         : _agents(std::make_shared<AgentMap>())
 {

--- a/supplementary/alica_ros1/alica_ros_proxy/include/communication/AlicaRosCommunication.h
+++ b/supplementary/alica_ros1/alica_ros_proxy/include/communication/AlicaRosCommunication.h
@@ -26,7 +26,7 @@ public:
     AlicaRosCommunication(const AlicaCommunicationHandlers& callbacks, ros::CallbackQueue& cb_queue = *ros::getGlobalCallbackQueue());
     virtual ~AlicaRosCommunication();
 
-    void tick();
+    void tick() override;
 
     void sendAllocationAuthority(const AllocationAuthorityInfo& aai) const override;
     void sendAlicaEngineInfo(const AlicaEngineInfo& bi) const override;

--- a/supplementary/alica_ros1/supplementary_tests/alica_supplementary_test_library/include/AcmeRuntimeCondition.h
+++ b/supplementary/alica_ros1/supplementary_tests/alica_supplementary_test_library/include/AcmeRuntimeCondition.h
@@ -11,7 +11,7 @@ class AcmeRuntimeCondition : public BasicCondition
 public:
     AcmeRuntimeCondition();
 
-    bool evaluate(std::shared_ptr<RunningPlan> rp, const Blackboard* globalBlackboard);
+    bool evaluate(std::shared_ptr<RunningPlan> rp, const Blackboard* globalBlackboard) override;
     // Factory method
     static std::shared_ptr<AcmeRuntimeCondition> create()
     {

--- a/supplementary/autodiff/include/autodiff/Exp.h
+++ b/supplementary/autodiff/include/autodiff/Exp.h
@@ -7,7 +7,7 @@ namespace autodiff
 class Exp : public UnaryFunction
 {
 public:
-    int accept(ITermVisitor* visitor);
+    int accept(ITermVisitor* visitor) override;
     void acceptRecursive(ITermVisitor* visitor) override;
 
     TermPtr aggregateConstants() override;

--- a/supplementary/constraintsolver/include/intervals/DownwardPropagator.h
+++ b/supplementary/constraintsolver/include/intervals/DownwardPropagator.h
@@ -49,7 +49,6 @@ private:
     bool updateInterval(autodiff::TermPtr t, double min, double max) const { return updateInterval(t, Interval<double>(min, max)); }
 
     autodiff::TermList* _changed;
-    UpwardPropagator* _up;
 };
 
 } /* namespace intervalpropagation */

--- a/supplementary/constraintsolver/include/intervals/UpwardPropagator.h
+++ b/supplementary/constraintsolver/include/intervals/UpwardPropagator.h
@@ -53,7 +53,6 @@ private:
     bool updateInterval(autodiff::TermPtr t, double min, double max) const { return updateInterval(t, Interval<double>(min, max)); }
 
     autodiff::TermList* _changed;
-    DownwardPropagator* _dp;
 };
 
 } /* namespace intervalpropagation */

--- a/supplementary/constraintsolver/src/intervals/DownwardPropagator.cpp
+++ b/supplementary/constraintsolver/src/intervals/DownwardPropagator.cpp
@@ -1,7 +1,7 @@
 
 #include "intervals/DownwardPropagator.h"
-//#define DEBUG_DP
-//#define DownwardPropagator_Call_Debug
+// #define DEBUG_DP
+// #define DownwardPropagator_Call_Debug
 
 #include "intervals/IntervalPropagator.h"
 #include "intervals/UnsolveableException.h"
@@ -26,7 +26,6 @@ using namespace autodiff;
 
 DownwardPropagator::DownwardPropagator()
         : _changed(nullptr)
-        , _up(nullptr)
 {
 }
 

--- a/supplementary/constraintsolver/src/intervals/IntervalPropagator.cpp
+++ b/supplementary/constraintsolver/src/intervals/IntervalPropagator.cpp
@@ -40,7 +40,6 @@ void IntervalPropagator::setGlobalRanges(
         holder.getVariables()[i]->editRange().setMax(ranges->at(i)->at(1));
     }
     this->globalRanges = ranges;
-    this->vars = vars;
     this->dim = vars->size();
     this->solver = solver;
     this->updates = 0;

--- a/supplementary/constraintsolver/src/intervals/UpwardPropagator.cpp
+++ b/supplementary/constraintsolver/src/intervals/UpwardPropagator.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "intervals/UpwardPropagator.h"
-//#define DEBUG_UP
+// #define DEBUG_UP
 
 #include "intervals/DownwardPropagator.h"
 #include "intervals/IntervalPropagator.h"
@@ -31,7 +31,6 @@ using std::numeric_limits;
 
 UpwardPropagator::UpwardPropagator()
         : _changed(nullptr)
-        , _dp(nullptr)
 {
 }
 

--- a/supplementary/constraintsolver/test/test_cnsmtgsolver.cpp
+++ b/supplementary/constraintsolver/test/test_cnsmtgsolver.cpp
@@ -19,12 +19,12 @@ using namespace alica::reasoner;
 using namespace alica::reasoner::cnsat;
 using namespace autodiff;
 
-//const int minCount = 2, maxCount = 20;
-//const int minform = 2, maxform = 2;
+// const int minCount = 2, maxCount = 20;
+// const int minform = 2, maxform = 2;
 const long maxTime = 15000; // 000000; //nanos
-//const int solverCount = 3;
-//const int count = 1000; // solving count
-//const double delta = 0.01;
+// const int solverCount = 3;
+// const int count = 1000; // solving count
+// const double delta = 0.01;
 
 class SolverStats
 {

--- a/supplementary/constraintsolver/test/test_cnsmtgsolver.cpp
+++ b/supplementary/constraintsolver/test/test_cnsmtgsolver.cpp
@@ -19,12 +19,12 @@ using namespace alica::reasoner;
 using namespace alica::reasoner::cnsat;
 using namespace autodiff;
 
-const int minCount = 2, maxCount = 20;
-const int minform = 2, maxform = 2;
+//const int minCount = 2, maxCount = 20;
+//const int minform = 2, maxform = 2;
 const long maxTime = 15000; // 000000; //nanos
-const int solverCount = 3;
-const int count = 1000; // solving count
-const double delta = 0.01;
+//const int solverCount = 3;
+//const int count = 1000; // solving count
+//const double delta = 0.01;
 
 class SolverStats
 {


### PR DESCRIPTION
Clang:
Type defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
Unused functions and private fields.
Unread variables.