### PR TITLE
Remove access to deprecated default value

### DIFF
--- a/alica_engine/include/engine/blackboard/BlackboardBlueprint.h
+++ b/alica_engine/include/engine/blackboard/BlackboardBlueprint.h
@@ -12,15 +12,19 @@ class BlackboardBlueprint
     struct KeyInfo
     {
         std::string type;
-        std::optional<std::string> defaultValue;
+        std::optional<std::string> defaultValue; // Deprecated
     };
 
 public:
     using const_iterator = std::unordered_map<std::string, KeyInfo>::const_iterator;
 
-    void addKey(const std::string& key, const std::string& type, std::optional<std::string> defaultValue)
+    [[deprecated("defaultValue no longer supported")]] void addKey(const std::string& key, const std::string& type, std::optional<std::string> defaultValue)
     {
         _keyInfo.emplace(std::piecewise_construct, std::forward_as_tuple(key), std::forward_as_tuple(KeyInfo{type, defaultValue}));
+    }
+    void addKey(const std::string& key, const std::string& type)
+    {
+        _keyInfo.emplace(std::piecewise_construct, std::forward_as_tuple(key), std::forward_as_tuple(KeyInfo{type, std::nullopt}));
     }
     const_iterator begin() const { return _keyInfo.begin(); }
     const_iterator end() const { return _keyInfo.end(); }

--- a/alica_engine/src/engine/modelmanagement/factories/BlackboardBlueprintFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/BlackboardBlueprintFactory.cpp
@@ -12,8 +12,7 @@ std::unique_ptr<BlackboardBlueprint> BlackboardBlueprintFactory::create(const YA
     for (const auto& entry : node) {
         auto key = getValue<std::string>(entry, Strings::key);
         auto type = getValue<std::string>(entry, Strings::stateType);
-        std::optional<std::string> defaultValue; // deprecated
-        blueprint->addKey(key, type, defaultValue);
+        blueprint->addKey(key, type);
     }
     return blueprint;
 }

--- a/alica_engine/src/engine/modelmanagement/factories/BlackboardBlueprintFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/BlackboardBlueprintFactory.cpp
@@ -12,10 +12,7 @@ std::unique_ptr<BlackboardBlueprint> BlackboardBlueprintFactory::create(const YA
     for (const auto& entry : node) {
         auto key = getValue<std::string>(entry, Strings::key);
         auto type = getValue<std::string>(entry, Strings::stateType);
-        std::optional<std::string> defaultValue;
-        if (!entry[Strings::defaultValue].IsNull()) {
-            defaultValue = getValue<std::string>(entry, Strings::defaultValue);
-        }
+        std::optional<std::string> defaultValue; // deprecated
         blueprint->addKey(key, type, defaultValue);
     }
     return blueprint;


### PR DESCRIPTION
Not a proper removal, as that will be done in https://github.com/rapyuta-robotics/alica/pull/380

This is just removing access to the deprecated field so that we can import plans exported by the latest plan designer