### PR TITLE
Undo API breaking change

### DIFF
--- a/supplementary/alica_ros1/alica_ros_proxy/include/logger/AlicaRosLogger.h
+++ b/supplementary/alica_ros1/alica_ros_proxy/include/logger/AlicaRosLogger.h
@@ -17,6 +17,10 @@ class AlicaRosLogger : public alica::IAlicaLogger
 {
 public:
     AlicaRosLogger(const Verbosity verbosity, const std::string& localAgentName);
+    [[deprecated]] AlicaRosLogger(const Verbosity verbosity, const std::string& localAgentName, const alica::AgentId localAgentId)
+            : AlicaRosLogger(verbosity, localAgentName)
+    {
+    }
     void log(const std::string& msg, const Verbosity verbosity, const std::string& logSpace) override;
 
 private:


### PR DESCRIPTION
https://github.com/rapyuta-robotics/alica/pull/426 made a change breaking compatibility with LBC.  This PR undoes that change by adding the function signature back in as deprecated