### PR TITLE
Fix Alica tracing error marking

### DIFF
--- a/supplementary/alica_tracing/src/tracing/Trace.cpp
+++ b/supplementary/alica_tracing/src/tracing/Trace.cpp
@@ -77,8 +77,8 @@ void Trace::log(const std::unordered_map<std::string_view, TraceValue>& fields)
 
 void Trace::markError(std::string_view description)
 {
-    _rawTrace->SetTag("error", true);
-    _rawTrace->SetTag("error.description", prepareStringView(description));
+    setTag("error", TraceValue(true));
+    setTag("error.description", TraceValue(description));
 }
 
 std::string Trace::context() const


### PR DESCRIPTION
The underlying tracing library doesn't work well with temporary string views for values it seems, reuse the `setTag` to prepare proper values.