### PR TITLE
Fix alica_standard_library cmake file

### DIFF
--- a/alica_standard_library/CMakeLists.txt
+++ b/alica_standard_library/CMakeLists.txt
@@ -45,6 +45,10 @@ install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION lib
 )
 
+install(DIRECTORY include/
+  DESTINATION include/
+  FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+)
 
 # Export targets to make package libraries
 export(EXPORT ${CMAKE_PROJECT_NAME}Targets
@@ -64,10 +68,13 @@ write_basic_package_version_file(
   COMPATIBILITY SameMajorVersion
 )
 
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+
 configure_package_config_file(
   ${CMAKE_PROJECT_NAME}Config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}Config.cmake
   INSTALL_DESTINATION ${ConfigPackageLocation}
+  PATH_VARS INCLUDE_INSTALL_DIR
 )
 
 install(FILES


### PR DESCRIPTION
Add INCLUDE_INSTALLDIR, which is required to allow other packages to include files like BasicPlans.h.