### PR TITLE
Remove master plan flag

### DIFF
--- a/alica_engine/include/engine/BasicPlan.h
+++ b/alica_engine/include/engine/BasicPlan.h
@@ -71,7 +71,6 @@ private:
     void doRun() override;
     void doTerminate() override;
 
-    bool _isMasterPlan;
     const Plan* _plan;
 };
 } // namespace alica

--- a/alica_engine/include/engine/model/Plan.h
+++ b/alica_engine/include/engine/model/Plan.h
@@ -40,7 +40,6 @@ public:
 
     int getMaxCardinality() const { return _maxCardinality; }
     int getMinCardinality() const { return _minCardinality; }
-    bool isMasterPlan() const { return _masterPlan; }
 
     UtilityFunction* getUtilityFunction() const { return _utilityFunction.get(); }
     double getUtilityThreshold() const { return _utilityThreshold; }
@@ -72,7 +71,6 @@ private:
     void setSuccessStates(const SuccessStateGrp& succesPoints);
     void setMaxCardinality(int maxCardinality);
     void setMinCardinality(int minCardinality);
-    void setMasterPlan(bool isMasterPlan);
     void setPostCondition(const PostCondition* postCondition);
     void setRuntimeCondition(RuntimeCondition* runtimeCondition);
     void setPreCondition(PreCondition* preCondition);
@@ -95,10 +93,6 @@ private:
      * The utility threshold, the higher, the less likely dynamic changes are.
      */
     double _utilityThreshold;
-    /**
-     *  Whether this plan is marked as a MasterPlan.
-     */
-    bool _masterPlan;
     /**
      * This behaviour's runtime condition.
      */

--- a/alica_engine/include/engine/modelmanagement/Strings.h
+++ b/alica_engine/include/engine/modelmanagement/Strings.h
@@ -65,7 +65,6 @@ static const std::string no_type = "no_type";
 static const std::string variableBindings = "variableBindings";
 static const std::string subPlan = "subPlan";
 static const std::string subVariable = "subVariable";
-static const std::string masterPlan = "masterPlan";
 static const std::string utilityThreshold = "utilityThreshold";
 static const std::string minCardinality = "minCardinality";
 static const std::string maxCardinality = "maxCardinality";

--- a/alica_engine/src/engine/BasicPlan.cpp
+++ b/alica_engine/src/engine/BasicPlan.cpp
@@ -9,7 +9,6 @@ namespace alica
 
 BasicPlan::BasicPlan(PlanContext& context)
         : RunnableObject(context.globalBlackboard, context.traceFactory, context.name)
-        , _isMasterPlan(context.planModel->isMasterPlan())
         , _plan(context.planModel)
 {
     if (_plan->getFrequency() < 1) {
@@ -28,12 +27,6 @@ BasicPlan::BasicPlan(PlanContext& context)
 
 void BasicPlan::doInit()
 {
-    // TODO Cleanup: do this after moving trace context setting to RunningPlan
-    /*if (_isMasterPlan) {
-        // Immediately send out the trace for the master plan, otherwise the traces will not be available until the application ends
-        _runnableObjectTracer.cleanupTraceContext();
-    }*/
-
     try {
         onInit();
     } catch (const std::exception& e) {

--- a/alica_engine/src/engine/model/Plan.cpp
+++ b/alica_engine/src/engine/model/Plan.cpp
@@ -17,7 +17,6 @@ Plan::Plan(ConfigChangeListener& configChangeListener, int64_t id)
         : AbstractPlan(id)
         , _minCardinality(0)
         , _maxCardinality(0)
-        , _masterPlan(false)
         , _utilityFunction(nullptr)
         , _utilityThreshold(1.0)
         , _runtimeCondition(nullptr)
@@ -90,11 +89,6 @@ void Plan::setMinCardinality(int minCardinality)
     _minCardinality = minCardinality;
 }
 
-void Plan::setMasterPlan(bool masterPlan)
-{
-    _masterPlan = masterPlan;
-}
-
 void Plan::setSuccessStates(const SuccessStateGrp& successStates)
 {
     _successStates = successStates;
@@ -104,7 +98,6 @@ std::string Plan::toString(std::string indent) const
 {
     std::stringstream ss;
     ss << indent << "#Plan: " << AbstractPlan::toString(indent);
-    ss << indent << "\tIsMasterPlan: " << this->_masterPlan << std::endl;
     ss << indent << "\tUtility Threshold: " << this->_utilityThreshold << std::endl;
     ss << indent << "\tfrequency: " << _frequency << std::endl;
     if (this->_preCondition != nullptr) {

--- a/alica_engine/src/engine/modelmanagement/factories/PlanFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/PlanFactory.cpp
@@ -36,9 +36,6 @@ Plan* PlanFactory::create(ConfigChangeListener& configChangeListener, const YAML
     if (Factory::isValid(node[alica::Strings::implementationName])) {
         plan->_implementationName = Factory::getValue<std::string>(node, alica::Strings::implementationName, "");
     }
-    if (Factory::isValid(node[alica::Strings::masterPlan])) {
-        plan->_masterPlan = node[alica::Strings::masterPlan].as<bool>();
-    }
     if (Factory::isValid(node[alica::Strings::frequency])) {
         plan->_frequency = node[alica::Strings::frequency].as<int>();
     }

--- a/alica_tests/src/test/test_alica_engine_plan_parser.cpp
+++ b/alica_tests/src/test/test_alica_engine_plan_parser.cpp
@@ -178,7 +178,7 @@ protected:
                     << "ID not part of testplans!" << endl;
             switch (plan->getId()) {
             case 1402488634525:
-                checkPlan(plan, 1402488634525, "AttackPlan", "", false, 0.1, 0, 2147483647);
+                checkPlan(plan, 1402488634525, "AttackPlan", "", 0.1, 0, 2147483647);
                 cout << "States: " << endl;
                 EXPECT_EQ(2u, plan->getStates().size()) << "Number of states didnt fit AttackPlan.pml state size." << endl;
                 for (const alica::State* s : plan->getStates()) {
@@ -255,7 +255,7 @@ protected:
                 cout << endl;
                 break;
             case 1402488893641:
-                checkPlan(plan, 1402488893641, "Defend", "", false, 0.1, 0, 2147483647);
+                checkPlan(plan, 1402488893641, "Defend", "", 0.1, 0, 2147483647);
                 cout << "States: " << endl;
                 EXPECT_EQ(4u, plan->getStates().size()) << "Number of states didnt fit Defend.pml state size." << endl;
                 for (const alica::State* s : plan->getStates()) {
@@ -324,7 +324,7 @@ protected:
                 cout << endl;
                 break;
             case 1402488870347:
-                checkPlan(plan, 1402488870347, "GoalPlan", "", false, 0.1, 0, 2147483647);
+                checkPlan(plan, 1402488870347, "GoalPlan", "", 0.1, 0, 2147483647);
                 checkPreCondition(plan->getPreCondition(), 1402489131988, "GoalPlanPreCondition", "Test PC", "", "DefaultPlugin", true);
                 cout << "States: " << endl;
                 EXPECT_EQ(3u, plan->getStates().size()) << "Number of states didnt fit GoalPlan.pml state size." << endl;
@@ -390,7 +390,7 @@ protected:
                 cout << endl;
                 break;
             case 1402488437260:
-                checkPlan(plan, 1402488437260, "MasterPlan", "comment", true, 0.1, 0, 2147483647);
+                checkPlan(plan, 1402488437260, "MasterPlan", "comment", 0.1, 0, 2147483647);
                 cout << "States: " << endl;
                 EXPECT_EQ(5u, plan->getStates().size()) << "Number of states didnt fit MasterPlan.pml state size." << endl;
                 for (const alica::State* s : plan->getStates()) {
@@ -466,7 +466,7 @@ protected:
                 cout << endl;
                 break;
             case 1402488770050:
-                checkPlan(plan, 1402488770050, "MidFieldPlayPlan", "", false, 0.1, 3, 2147483647);
+                checkPlan(plan, 1402488770050, "MidFieldPlayPlan", "", 0.1, 3, 2147483647);
                 checkRuntimeCondition(plan->getRuntimeCondition(), 1402489260911, "MidFieldPlayPlanRuntimeCondition", "Test RC", "", "DefaultPlugin");
                 cout << "States: " << endl;
                 EXPECT_EQ(5u, plan->getStates().size()) << "Number of states didnt fit MidFieldPlayPlan.pml state size." << endl;
@@ -546,7 +546,7 @@ protected:
                 cout << endl;
                 break;
             case 1402489318663:
-                checkPlan(plan, 1402489318663, "Tackle", "", false, 0.1, 0, 2147483647);
+                checkPlan(plan, 1402489318663, "Tackle", "", 0.1, 0, 2147483647);
                 cout << "States: " << endl;
                 EXPECT_EQ(1u, plan->getStates().size()) << "Number of states didnt fit Tackle.pml state size." << endl;
                 for (const alica::State* s : plan->getStates()) {

--- a/alica_tests/src/test/test_alica_engine_plan_parser.cpp
+++ b/alica_tests/src/test/test_alica_engine_plan_parser.cpp
@@ -100,11 +100,9 @@ protected:
         EXPECT_STREQ(taskName.c_str(), ep->getTask()->getName().c_str()) << "Wrong taskName!" << endl;
     }
 
-    static void checkPlan(
-            const alica::Plan* plan, long id, string name, string comment, bool masterPlan, double utilityThreshold, int minCardinality, int maxCardinality)
+    static void checkPlan(const alica::Plan* plan, long id, string name, string comment, double utilityThreshold, int minCardinality, int maxCardinality)
     {
         checkAlicaElement(plan, id, name, comment);
-        EXPECT_EQ(masterPlan, plan->isMasterPlan()) << "MasterPlan true instead of false!" << endl;
         EXPECT_EQ(utilityThreshold, plan->getUtilityThreshold()) << "Wrong utilityThreshold!" << endl;
         EXPECT_EQ(minCardinality, plan->getMinCardinality()) << "Wrong minCardinality!" << endl;
         EXPECT_EQ(maxCardinality, plan->getMaxCardinality()) << "Wrong maxCardinality!" << endl;


### PR DESCRIPTION
This flag is not useful in my opinion, as which plan is the master plan is set in the context and is not a property of the plan itself.