### PR TITLE
Prevent dynamic allocation for plans with negative utility threshold

### DIFF
--- a/alica_engine/src/engine/RuleBook.cpp
+++ b/alica_engine/src/engine/RuleBook.cpp
@@ -160,7 +160,7 @@ PlanChange RuleBook::dynamicAllocationRule(RunningPlan& r)
 
     const Plan* p = static_cast<const Plan*>(r.getActivePlan());
 
-    if (p->getUtilityThreshold() < 0) {
+    if (!p || p->getUtilityThreshold() < 0) {
         return PlanChange::NoChange;
     }
 

--- a/alica_engine/src/engine/RuleBook.cpp
+++ b/alica_engine/src/engine/RuleBook.cpp
@@ -157,6 +157,13 @@ PlanChange RuleBook::dynamicAllocationRule(RunningPlan& r)
     if (!r.getCycleManagement().mayDoUtilityCheck()) {
         return PlanChange::NoChange;
     }
+
+    const Plan* p = static_cast<const Plan*>(r.getActivePlan());
+
+    if (p->getUtilityThreshold() < 0) {
+        return PlanChange::NoChange;
+    }
+
     const RunningPlan* parent = r.getParent();
 
     AgentGrp robots;
@@ -167,7 +174,6 @@ PlanChange RuleBook::dynamicAllocationRule(RunningPlan& r)
     if (newr == nullptr) {
         return PlanChange::NoChange;
     }
-    const Plan* p = static_cast<const Plan*>(r.getActivePlan());
 
     double possibleUtil = newr->getAssignment().getLastUtilityValue();
 

--- a/alica_engine/src/engine/RuleBook.cpp
+++ b/alica_engine/src/engine/RuleBook.cpp
@@ -160,7 +160,7 @@ PlanChange RuleBook::dynamicAllocationRule(RunningPlan& r)
 
     const Plan* p = static_cast<const Plan*>(r.getActivePlan());
 
-    if (!p || p->getUtilityThreshold() < 0) {
+    if (!p || p->getUtilityThreshold() < 0.) {
         return PlanChange::NoChange;
     }
 

--- a/supplementary/alica_ros1/alica_ros_turtlesim/etc/plans/Simulation.pml
+++ b/supplementary/alica_ros1/alica_ros_turtlesim/etc/plans/Simulation.pml
@@ -291,6 +291,6 @@
       "synchronisation": null
     }
   ],
-  "utilityThreshold": 0.0,
+  "utilityThreshold": -1.0,
   "variables": []
 }


### PR DESCRIPTION
- Prevents dynamic allocation for plans with negative utility threshold
- Skips the creation of RunningPlans and unnecessary calculations
