### PR TITLE
unsubscribe from config change listener on destruction of CycleManage…

### DIFF
--- a/alica_engine/include/engine/ConfigChangeListener.h
+++ b/alica_engine/include/engine/ConfigChangeListener.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <functional>
-#include <vector>
+#include <unordered_map>
 #include <yaml-cpp/yaml.h>
 
 #include "engine/Types.h"
@@ -16,12 +16,14 @@ public:
     using ConfigChangeSubscriber = std::function<void(ReloadFunction)>;
 
     ConfigChangeListener(YAML::Node& config);
-    void subscribe(ReloadFunction reloadFunction);
+    uint64_t subscribe(ReloadFunction reloadFunction);
+    void unsubscribe(uint64_t callbackId);
     void reloadConfig(const YAML::Node& config);
     YAML::Node& getConfig() const;
 
 private:
-    std::vector<ReloadFunction> _configChangeListenerCBs;
+    std::unordered_map<uint64_t, ReloadFunction> _configChangeListenerCBs;
     YAML::Node& _config;
+    uint64_t _callbackIdCounter;
 };
 } // namespace alica

--- a/alica_engine/include/engine/allocationauthority/CycleManager.h
+++ b/alica_engine/include/engine/allocationauthority/CycleManager.h
@@ -55,9 +55,11 @@ private:
     const AlicaClock& _clock;
     const TeamManager& _teamManager;
     const PlanRepository& _planRepository;
+    ConfigChangeListener& _configChangeListener;
     std::vector<AllocationDifference> _allocationHistory;
     int _newestAllocationDifference;
     int _maxAllocationCycles;
+    uint64_t _reloadCallbackId;
     bool _enabled;
     AgentId _myID;
     AlicaTime _overrideTimestamp;

--- a/alica_engine/src/engine/ConfigChangeListener.cpp
+++ b/alica_engine/src/engine/ConfigChangeListener.cpp
@@ -23,8 +23,8 @@ void ConfigChangeListener::unsubscribe(uint64_t callbackId)
 
 void ConfigChangeListener::reloadConfig(const YAML::Node& config)
 {
-    for (auto it = _configChangeListenerCBs.begin(); it != _configChangeListenerCBs.end(); it++) {
-        it->second(config);
+    for (const auto& [id, reloadCallback] : _configChangeListenerCBs) {
+        reloadCallback(config);
     }
 }
 

--- a/alica_engine/src/engine/ConfigChangeListener.cpp
+++ b/alica_engine/src/engine/ConfigChangeListener.cpp
@@ -5,18 +5,26 @@ namespace alica
 
 ConfigChangeListener::ConfigChangeListener(YAML::Node& config)
         : _config(config)
+        , _callbackIdCounter(0)
 {
 }
 
-void ConfigChangeListener::subscribe(ReloadFunction reloadFunction)
+uint64_t ConfigChangeListener::subscribe(ReloadFunction reloadFunction)
 {
-    _configChangeListenerCBs.push_back(reloadFunction);
+    _callbackIdCounter++;
+    _configChangeListenerCBs[_callbackIdCounter] = reloadFunction;
+    return _callbackIdCounter;
+}
+
+void ConfigChangeListener::unsubscribe(uint64_t callbackId)
+{
+    _configChangeListenerCBs.erase(callbackId);
 }
 
 void ConfigChangeListener::reloadConfig(const YAML::Node& config)
 {
-    for (auto reloadFunction : _configChangeListenerCBs) {
-        reloadFunction(config);
+    for (auto it = _configChangeListenerCBs.begin(); it != _configChangeListenerCBs.end(); it++) {
+        it->second(config);
     }
 }
 

--- a/alica_engine/src/engine/allocationauthority/CycleManager.cpp
+++ b/alica_engine/src/engine/allocationauthority/CycleManager.cpp
@@ -36,13 +36,17 @@ CycleManager::CycleManager(ConfigChangeListener& configChangeListener, const Ali
         , _newestAllocationDifference(0)
         , _runningPlan(rp)
         , _myID(_teamManager.getLocalAgentID())
+        , _configChangeListener(configChangeListener)
 {
     auto reloadFunctionPtr = std::bind(&CycleManager::reload, this, std::placeholders::_1);
-    configChangeListener.subscribe(reloadFunctionPtr);
+    _reloadCallbackId = configChangeListener.subscribe(reloadFunctionPtr);
     reload(configChangeListener.getConfig());
 }
 
-CycleManager::~CycleManager() {}
+CycleManager::~CycleManager()
+{
+    _configChangeListener.unsubscribe(_reloadCallbackId);
+}
 
 void CycleManager::reload(const YAML::Node& config)
 {

--- a/alica_tests/src/test/test_config_change.cpp
+++ b/alica_tests/src/test/test_config_change.cpp
@@ -4,6 +4,7 @@
 
 #include "engine/planselector/PartialAssignment.h"
 #include <DynamicBehaviourCreator.h>
+#include <engine/ConfigChangeListener.h>
 
 namespace alica
 {
@@ -93,6 +94,24 @@ TEST_F(AlicaNotInitialized, TestConfigUpdatesWithVector)
 
     EXPECT_TRUE(ac->getConfig()["Local"]["IsGoalie"].as<bool>());
     EXPECT_EQ(1000.0f, ac->getConfig()["Local"]["AverageTranslation"].as<float>());
+}
+
+TEST(ConfigChangeListenerTest, TestConfigSubscribeAndUnsubscribe)
+{
+    // create new configChangeListener with empty config node
+    YAML::Node cfg;
+    alica::ConfigChangeListener ccl(cfg);
+    bool called = false;
+
+    std::function<void(const YAML::Node& cfg)> cb = [&](const YAML::Node& cfg) { called = true; };
+    uint64_t cbId = ccl.subscribe(cb);
+    ccl.reloadConfig(cfg);
+    ASSERT_TRUE(called);
+
+    ccl.unsubscribe(cbId);
+    called = false;
+    ccl.reloadConfig(cfg);
+    ASSERT_FALSE(called);
 }
 } // namespace
 } // namespace alica


### PR DESCRIPTION
On each iteration of the alica main loop, during the dynamic allocation, RunningPlans with their own instance of CycleManager are created. On creation, the CycleManager will subscribe to the ConfigChangeListener, creating an std::function and storing it in the ConfigChangeListener.

When the RunningPlan and the CycleManager are destroyed, the std::function remains as a callback in the ConfigChangeListener. Over time the number of subsribers keeps growing and increases the applications memory consumption. To prevent that, CycleManagers now unsubscribe from the ConfigChangeListener on destruction.