### PR TITLE
Remove configuration leftovers

### DIFF
--- a/alica_engine/include/engine/model/ConfAbstractPlanWrapper.h
+++ b/alica_engine/include/engine/model/ConfAbstractPlanWrapper.h
@@ -7,7 +7,6 @@
 namespace alica
 {
 class AbstractPlan;
-class Configuration;
 class ConfAbstractPlanWrapperFactory;
 
 class ConfAbstractPlanWrapper : public AlicaElement
@@ -18,14 +17,12 @@ public:
 
     const AbstractPlan* getAbstractPlan() const { return _abstractPlan; }
     void setAbstractPlan(const AbstractPlan* abstractPlan) { _abstractPlan = abstractPlan; }
-    const Configuration* getConfiguration() const { return _configuration; }
     const KeyMapping* getKeyMapping() const { return _keyMapping.get(); }
 
 private:
     friend ConfAbstractPlanWrapperFactory;
 
     const AbstractPlan* _abstractPlan;
-    const Configuration* _configuration;
     std::unique_ptr<KeyMapping> _keyMapping;
 };
 } // namespace alica

--- a/alica_engine/include/engine/modelmanagement/factories/Factory.h
+++ b/alica_engine/include/engine/modelmanagement/factories/Factory.h
@@ -42,7 +42,6 @@ protected:
     static ReferenceList epTaskReferences;
     static ReferenceList planTypePlanReferences;
     static ReferenceList wrapperAbstractPlanReferences;
-    static ReferenceList wrapperConfigurationReferences;
     static TripleReferenceList roleTaskReferences;
     static ModelManager* modelManager;
 

--- a/alica_engine/src/engine/model/ConfAbstractPlanWrapper.cpp
+++ b/alica_engine/src/engine/model/ConfAbstractPlanWrapper.cpp
@@ -3,7 +3,6 @@ namespace alica
 {
 ConfAbstractPlanWrapper::ConfAbstractPlanWrapper()
         : _abstractPlan(nullptr)
-        , _configuration(nullptr)
         , _keyMapping(nullptr)
 {
 }

--- a/alica_engine/src/engine/modelmanagement/factories/ConfAbstractPlanWrapperFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/ConfAbstractPlanWrapperFactory.cpp
@@ -32,13 +32,5 @@ void ConfAbstractPlanWrapperFactory::attachReferences()
         wrapper->_abstractPlan = abstractPlan;
     }
     Factory::wrapperAbstractPlanReferences.clear();
-
-    // wrapperConfiguration references
-    for (std::pair<int64_t, int64_t> pairs : Factory::wrapperConfigurationReferences) {
-        ConfAbstractPlanWrapper* wrapper = (ConfAbstractPlanWrapper*) Factory::getElement(pairs.first);
-        Configuration* configuration = (Configuration*) Factory::getElement(pairs.second);
-        wrapper->_configuration = configuration;
-    }
-    Factory::wrapperConfigurationReferences.clear();
 }
 } // namespace alica

--- a/alica_engine/src/engine/modelmanagement/factories/Factory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/Factory.cpp
@@ -28,7 +28,6 @@ ReferenceList Factory::epStateReferences;
 ReferenceList Factory::epTaskReferences;
 ReferenceList Factory::planTypePlanReferences;
 ReferenceList Factory::wrapperAbstractPlanReferences;
-ReferenceList Factory::wrapperConfigurationReferences;
 TripleReferenceList Factory::roleTaskReferences;
 ModelManager* Factory::modelManager;
 
@@ -83,7 +82,6 @@ void Factory::setModelManager(alica::ModelManager* modelManager)
     epTaskReferences.clear();
     planTypePlanReferences.clear();
     wrapperAbstractPlanReferences.clear();
-    wrapperConfigurationReferences.clear();
     roleTaskReferences.clear();
     Factory::modelManager = modelManager;
 }

--- a/alica_test_utility/include/alica/test/Util.h
+++ b/alica_test_utility/include/alica/test/Util.h
@@ -70,8 +70,8 @@ namespace alica::test
 class Util
 {
 public:
-    static BasicBehaviour* getBasicBehaviour(alica::AlicaEngine* ae, int64_t behaviourID, int64_t configurationID);
-    static BasicPlan* getBasicPlan(alica::AlicaEngine* ae, int64_t planId, int64_t configurationId);
+    static BasicBehaviour* getBasicBehaviour(alica::AlicaEngine* ae, int64_t behaviourID);
+    static BasicPlan* getBasicPlan(alica::AlicaEngine* ae, int64_t planId);
     static bool hasPlanSucceeded(alica::AlicaEngine* ae, int64_t id);
     static bool isStateActive(alica::AlicaEngine* ae, int64_t id);
     static bool isPlanActive(alica::AlicaEngine* ae, int64_t id);

--- a/alica_test_utility/src/Util.cpp
+++ b/alica_test_utility/src/Util.cpp
@@ -5,7 +5,7 @@
 
 namespace alica::test
 {
-BasicBehaviour* Util::getBasicBehaviour(alica::AlicaEngine* ae, int64_t behaviourID, [[maybe_unused]] int64_t configurationID)
+BasicBehaviour* Util::getBasicBehaviour(alica::AlicaEngine* ae, int64_t behaviourID)
 {
     return getBasicBehaviourHelper(ae->editPlanBase().getRootNode(), behaviourID);
 }
@@ -31,7 +31,7 @@ BasicBehaviour* Util::getBasicBehaviourHelper(const RunningPlan* rp, int64_t beh
     return nullptr;
 }
 
-BasicPlan* Util::getBasicPlan(alica::AlicaEngine* ae, int64_t planId, [[maybe_unused]] int64_t configurationId)
+BasicPlan* Util::getBasicPlan(alica::AlicaEngine* ae, int64_t planId)
 {
     return getBasicPlanHelper(ae->getPlanBase().getRootNode(), planId);
 }

--- a/alica_tests/src/test/test_alica_behaviourtrigger.cpp
+++ b/alica_tests/src/test/test_alica_behaviourtrigger.cpp
@@ -35,37 +35,37 @@ TEST_F(AlicaBehaviourTrigger, triggerTest)
     alica::AlicaTime duration = alica::AlicaTime::milliseconds(100);
     ae->getAlicaClock().sleep(duration);
 
-    EXPECT_EQ(dynamic_cast<alica::TriggerA*>(alica::test::Util::getBasicBehaviour(ae, 1428508297492, 0))->callCounter, 0);
-    EXPECT_EQ(dynamic_cast<alica::TriggerB*>(alica::test::Util::getBasicBehaviour(ae, 1428508316905, 0))->callCounter, 0);
-    EXPECT_EQ(dynamic_cast<alica::TriggerC*>(alica::test::Util::getBasicBehaviour(ae, 1428508355209, 0))->callCounter, 0);
-    EXPECT_EQ(dynamic_cast<alica::NotToTrigger*>(alica::test::Util::getBasicBehaviour(ae, 1429017274116, 0))->callCounter, 0);
+    EXPECT_EQ(dynamic_cast<alica::TriggerA*>(alica::test::Util::getBasicBehaviour(ae, 1428508297492))->callCounter, 0);
+    EXPECT_EQ(dynamic_cast<alica::TriggerB*>(alica::test::Util::getBasicBehaviour(ae, 1428508316905))->callCounter, 0);
+    EXPECT_EQ(dynamic_cast<alica::TriggerC*>(alica::test::Util::getBasicBehaviour(ae, 1428508355209))->callCounter, 0);
+    EXPECT_EQ(dynamic_cast<alica::NotToTrigger*>(alica::test::Util::getBasicBehaviour(ae, 1429017274116))->callCounter, 0);
 
-    dynamic_cast<alica::TriggerA*>(alica::test::Util::getBasicBehaviour(ae, 1428508297492, 0))->doTrigger();
-    dynamic_cast<alica::TriggerB*>(alica::test::Util::getBasicBehaviour(ae, 1428508316905, 0))->doTrigger();
-    dynamic_cast<alica::TriggerC*>(alica::test::Util::getBasicBehaviour(ae, 1428508355209, 0))->doTrigger();
-
-    ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(33));
-
-    dynamic_cast<alica::TriggerA*>(alica::test::Util::getBasicBehaviour(ae, 1428508297492, 0))->doTrigger();
-    dynamic_cast<alica::TriggerB*>(alica::test::Util::getBasicBehaviour(ae, 1428508316905, 0))->doTrigger();
-    dynamic_cast<alica::TriggerC*>(alica::test::Util::getBasicBehaviour(ae, 1428508355209, 0))->doTrigger();
+    dynamic_cast<alica::TriggerA*>(alica::test::Util::getBasicBehaviour(ae, 1428508297492))->doTrigger();
+    dynamic_cast<alica::TriggerB*>(alica::test::Util::getBasicBehaviour(ae, 1428508316905))->doTrigger();
+    dynamic_cast<alica::TriggerC*>(alica::test::Util::getBasicBehaviour(ae, 1428508355209))->doTrigger();
 
     ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(33));
 
-    dynamic_cast<alica::TriggerA*>(alica::test::Util::getBasicBehaviour(ae, 1428508297492, 0))->doTrigger();
-    dynamic_cast<alica::TriggerB*>(alica::test::Util::getBasicBehaviour(ae, 1428508316905, 0))->doTrigger();
-    dynamic_cast<alica::TriggerC*>(alica::test::Util::getBasicBehaviour(ae, 1428508355209, 0))->doTrigger();
+    dynamic_cast<alica::TriggerA*>(alica::test::Util::getBasicBehaviour(ae, 1428508297492))->doTrigger();
+    dynamic_cast<alica::TriggerB*>(alica::test::Util::getBasicBehaviour(ae, 1428508316905))->doTrigger();
+    dynamic_cast<alica::TriggerC*>(alica::test::Util::getBasicBehaviour(ae, 1428508355209))->doTrigger();
 
     ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(33));
 
-    dynamic_cast<alica::TriggerC*>(alica::test::Util::getBasicBehaviour(ae, 1428508355209, 0))->doTrigger();
+    dynamic_cast<alica::TriggerA*>(alica::test::Util::getBasicBehaviour(ae, 1428508297492))->doTrigger();
+    dynamic_cast<alica::TriggerB*>(alica::test::Util::getBasicBehaviour(ae, 1428508316905))->doTrigger();
+    dynamic_cast<alica::TriggerC*>(alica::test::Util::getBasicBehaviour(ae, 1428508355209))->doTrigger();
+
+    ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(33));
+
+    dynamic_cast<alica::TriggerC*>(alica::test::Util::getBasicBehaviour(ae, 1428508355209))->doTrigger();
 
     ae->getAlicaClock().sleep(duration * 2);
 
-    EXPECT_EQ(dynamic_cast<alica::TriggerA*>(alica::test::Util::getBasicBehaviour(ae, 1428508297492, 0))->callCounter, 3);
-    EXPECT_EQ(dynamic_cast<alica::TriggerB*>(alica::test::Util::getBasicBehaviour(ae, 1428508316905, 0))->callCounter, 3);
-    EXPECT_EQ(dynamic_cast<alica::TriggerC*>(alica::test::Util::getBasicBehaviour(ae, 1428508355209, 0))->callCounter, 4);
-    EXPECT_EQ(dynamic_cast<alica::NotToTrigger*>(alica::test::Util::getBasicBehaviour(ae, 1429017274116, 0))->callCounter, 0);
+    EXPECT_EQ(dynamic_cast<alica::TriggerA*>(alica::test::Util::getBasicBehaviour(ae, 1428508297492))->callCounter, 3);
+    EXPECT_EQ(dynamic_cast<alica::TriggerB*>(alica::test::Util::getBasicBehaviour(ae, 1428508316905))->callCounter, 3);
+    EXPECT_EQ(dynamic_cast<alica::TriggerC*>(alica::test::Util::getBasicBehaviour(ae, 1428508355209))->callCounter, 4);
+    EXPECT_EQ(dynamic_cast<alica::NotToTrigger*>(alica::test::Util::getBasicBehaviour(ae, 1429017274116))->callCounter, 0);
 }
 } // namespace
 } // namespace alica

--- a/alica_tests/src/test/test_alica_condition_plan.cpp
+++ b/alica_tests/src/test/test_alica_condition_plan.cpp
@@ -69,7 +69,7 @@ TEST_F(AlicaConditionPlan, solverTest)
     ac->stepEngine();
     ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(100));
 
-    auto constraintUsingBehaviour = dynamic_cast<alica::ConstraintUsingBehaviour*>(alica::test::Util::getBasicBehaviour(ae, 1414068597716, 0));
+    auto constraintUsingBehaviour = dynamic_cast<alica::ConstraintUsingBehaviour*>(alica::test::Util::getBasicBehaviour(ae, 1414068597716));
     ASSERT_NE(constraintUsingBehaviour, nullptr);
     ASSERT_GT(constraintUsingBehaviour->getCallCounter(), 0);
 

--- a/alica_tests/src/test/test_alica_multi_agent_plan.cpp
+++ b/alica_tests/src/test/test_alica_multi_agent_plan.cpp
@@ -74,8 +74,8 @@ TEST_F(AlicaMultiAgent, runMultiAgentPlan)
             ASSERT_TRUE(alica::test::Util::isPlanActive(aes[1], 1413200862180));
         }
         if (i == 15) {
-            ASSERT_GT(dynamic_cast<alica::Attack*>(alica::test::Util::getBasicBehaviour(aes[0], 1402488848841, 0))->callCounter, 5);
-            if (dynamic_cast<alica::Attack*>(alica::test::Util::getBasicBehaviour(aes[0], 1402488848841, 0))->callCounter > 3) {
+            ASSERT_GT(dynamic_cast<alica::Attack*>(alica::test::Util::getBasicBehaviour(aes[0], 1402488848841))->callCounter, 5);
+            if (dynamic_cast<alica::Attack*>(alica::test::Util::getBasicBehaviour(aes[0], 1402488848841))->callCounter > 3) {
                 twm1->setTransitionCondition1413201052549(true);
                 twm2->setTransitionCondition1413201052549(true);
                 twm1->setTransitionCondition1413201370590(true);

--- a/alica_tests/src/test/test_alica_scheduling.cpp
+++ b/alica_tests/src/test/test_alica_scheduling.cpp
@@ -124,8 +124,8 @@ TEST_F(AlicaSchedulingPlan, behaviourSuccessFailureCheck)
     ac->stepEngine();
 
     // std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    SLEEP_UNTIL(alica::test::Util::getBasicBehaviour(ae, 1629895901559, 0) != nullptr);
-    auto behAAA = alica::test::Util::getBasicBehaviour(ae, 1629895901559, 0);
+    SLEEP_UNTIL(alica::test::Util::getBasicBehaviour(ae, 1629895901559) != nullptr);
+    auto behAAA = alica::test::Util::getBasicBehaviour(ae, 1629895901559);
     ASSERT_FALSE(wm->behAAASuccessInInit);
     ASSERT_FALSE(wm->behAAAFailureInInit);
     ASSERT_FALSE(behAAA->isSuccess());
@@ -161,7 +161,7 @@ TEST_F(AlicaSchedulingPlan, behaviourSuccessFailureCheck)
     ac->stepEngine();
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    behAAA = alica::test::Util::getBasicBehaviour(ae, 1629895901559, 0);
+    behAAA = alica::test::Util::getBasicBehaviour(ae, 1629895901559);
     ASSERT_FALSE(wm->behAAASuccessInInit);
     ASSERT_FALSE(wm->behAAAFailureInInit);
     ASSERT_FALSE(behAAA->isSuccess());

--- a/alica_tests/src/test/test_alica_simple_plan.cpp
+++ b/alica_tests/src/test/test_alica_simple_plan.cpp
@@ -65,14 +65,14 @@ TEST_F(AlicaSimplePlan, runBehaviourInSimplePlan)
     EXPECT_TRUE(alica::test::Util::isPlanActive(ae, 1402488848841));
 
     // We assume at least 30 calls to Attack in (3 * sleepTime) seconds.
-    while (dynamic_cast<alica::Attack*>(alica::test::Util::getBasicBehaviour(ae, 1402488848841, 0))->callCounter < 30 && timeoutCount < 3) {
+    while (dynamic_cast<alica::Attack*>(alica::test::Util::getBasicBehaviour(ae, 1402488848841))->callCounter < 30 && timeoutCount < 3) {
         ae->getAlicaClock().sleep(sleepTime);
         timeoutCount++;
     }
     timeoutCount = 0;
 
-    EXPECT_GE(dynamic_cast<alica::Attack*>(alica::test::Util::getBasicBehaviour(ae, 1402488848841, 0))->callCounter, 30);
-    EXPECT_GT(dynamic_cast<alica::Attack*>(alica::test::Util::getBasicBehaviour(ae, 1402488848841, 0))->initCounter, 0);
+    EXPECT_GE(dynamic_cast<alica::Attack*>(alica::test::Util::getBasicBehaviour(ae, 1402488848841))->callCounter, 30);
+    EXPECT_GT(dynamic_cast<alica::Attack*>(alica::test::Util::getBasicBehaviour(ae, 1402488848841))->initCounter, 0);
     CounterClass::called = 0;
 }
 } // namespace

--- a/alica_tests/src/test/test_blackboard.cpp
+++ b/alica_tests/src/test/test_blackboard.cpp
@@ -207,9 +207,9 @@ TEST_F(TestBlackboard, testNotInheritBlackboardFlag)
     ae->start();
     ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(100));
     // Behaviour has inheritBlackboard set to false
-    EXPECT_FALSE(alica::test::Util::getBasicBehaviour(ae, 831400441334251602, 0)->getInheritBlackboard());
+    EXPECT_FALSE(alica::test::Util::getBasicBehaviour(ae, 831400441334251602)->getInheritBlackboard());
     // Plan has inheritBlackboard set to false
-    EXPECT_FALSE(alica::test::Util::getBasicPlan(ae, 1692837668719979457, 0)->getInheritBlackboard());
+    EXPECT_FALSE(alica::test::Util::getBasicPlan(ae, 1692837668719979457)->getInheritBlackboard());
 }
 
 TEST_F(TestBlackboard, testWithoutPlan)

--- a/alica_tests/src/test/test_inherit_blackboard.cpp
+++ b/alica_tests/src/test/test_inherit_blackboard.cpp
@@ -31,9 +31,9 @@ TEST_F(TestInheritBlackboard, testInheritBlackboardFlag)
     ae->start();
     ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(100));
     // Behaviour has inheritBlackboard set to false
-    EXPECT_TRUE(alica::test::Util::getBasicBehaviour(ae, 831400441334251600, 0)->getInheritBlackboard());
+    EXPECT_TRUE(alica::test::Util::getBasicBehaviour(ae, 831400441334251600)->getInheritBlackboard());
     // Plan has inheritBlackboard set to false
-    EXPECT_TRUE(alica::test::Util::getBasicPlan(ae, 1692837668719979400, 0)->getInheritBlackboard());
+    EXPECT_TRUE(alica::test::Util::getBasicPlan(ae, 1692837668719979400)->getInheritBlackboard());
 }
 
 } // namespace


### PR DESCRIPTION
In a previous PR, support for configurations was removed. This PR removes some leftovers.