### PR TITLE
Ignore unknown agents

### DIFF
--- a/alica_engine/src/engine/model/ForallAgents.cpp
+++ b/alica_engine/src/engine/model/ForallAgents.cpp
@@ -4,6 +4,7 @@
 #include "engine/TeamObserver.h"
 #include "engine/collections/AgentVariables.h"
 #include "engine/collections/RobotEngineData.h"
+#include "engine/logging/Logging.h"
 #include "engine/model/AbstractPlan.h"
 #include "engine/model/DomainVariable.h"
 #include "engine/model/Plan.h"
@@ -27,6 +28,7 @@ ForallAgents::Result ForallAgents::TryAddId(AgentId id, std::vector<AgentVariabl
 {
     if (!tm.getAgentByID(id)) {
         // Assignment contains unknown agent because of authority role, ignore unknown agent
+        Logging::logWarn("ForallAgents") << "Can not add domain variable for agent with id " << id << ": Agent is not discovered yet!";
         return NONE;
     }
 

--- a/alica_engine/src/engine/model/ForallAgents.cpp
+++ b/alica_engine/src/engine/model/ForallAgents.cpp
@@ -25,6 +25,11 @@ ForallAgents::~ForallAgents() {}
 
 ForallAgents::Result ForallAgents::TryAddId(AgentId id, std::vector<AgentVariables>& io_agentVarsInScope, const TeamManager& tm) const
 {
+    if (!tm.getAgentByID(id)) {
+        // Assignment contains unknown agent because of authority role, ignore unknown agent
+        return NONE;
+    }
+
     std::vector<AgentVariables>::iterator it =
             std::find_if(io_agentVarsInScope.begin(), io_agentVarsInScope.end(), [id](const AgentVariables& av) { return av.getId() == id; });
 

--- a/alica_engine/src/engine/model/ForallAgents.cpp
+++ b/alica_engine/src/engine/model/ForallAgents.cpp
@@ -27,7 +27,7 @@ ForallAgents::~ForallAgents() {}
 ForallAgents::Result ForallAgents::TryAddId(AgentId id, std::vector<AgentVariables>& io_agentVarsInScope, const TeamManager& tm) const
 {
     if (!tm.getAgentByID(id)) {
-        // Assignment contains unknown agent because of authority role, ignore unknown agent
+        // Assignment contains unknown agent because of authority rule, ignore unknown agent
         Logging::logWarn("ForallAgents") << "Can not add domain variable for agent with id " << id << ": Agent is not discovered yet!";
         return NONE;
     }


### PR DESCRIPTION
Because of the authority rule, an agent might have an Assignment with agents it does not know about yet. This will lead to a crash in the quantifier ForAllAgents.cpp and happens with a larger number of agents (for me 25+) on high system load. Therefore we have to ignore information about unknown agents. After some time, agents will know about all other agents.