### PR TITLE
Logging fixes

### DIFF
--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -448,19 +448,18 @@ private:
     friend class ::alica::AlicaTestsEngineGetter;
     friend class ::alica::test::TestContext;
 
-    std::string _localAgentName;
-    YAML::Node _configRootNode;
-
-    std::atomic<uint32_t> _validTag;
     // WARNING: Initialization order dependencies!
     // Please do not change the declaration order of members.
+    const AlicaContextParams _alicaContextParams;
+    std::string _localAgentName;
+    YAML::Node _configRootNode;
+    std::atomic<uint32_t> _validTag;
     std::unique_ptr<AlicaClock> _clock;
     std::unique_ptr<IAlicaCommunication> _communicator;
     std::unique_ptr<AlicaEngine> _engine;
     std::unordered_map<size_t, std::unique_ptr<ISolverBase>> _solvers;
     std::unique_ptr<IAlicaTimerFactory> _timerFactory;
     std::unique_ptr<IAlicaTraceFactory> _traceFactory;
-    const AlicaContextParams _alicaContextParams;
     static const std::unordered_map<std::string, Verbosity> _verbosityStringToVerbosityMap;
 
     bool _initialized = false;
@@ -586,7 +585,7 @@ void AlicaContext::setLogger(Args&&... args)
             verbosity = it->second;
         }
     }
-    AlicaLogger::create<LoggerType>(verbosity, _localAgentName, std::forward<Args>(args)...);
+    AlicaLogger::set<LoggerType>(verbosity, _localAgentName, std::forward<Args>(args)...);
 }
 
 // Some options can be set before AlicaContext::init but become available only after the init is called

--- a/alica_engine/include/engine/logging/AlicaLogger.h
+++ b/alica_engine/include/engine/logging/AlicaLogger.h
@@ -9,17 +9,13 @@ class AlicaLogger
 {
 public:
     template <class LoggerType, class... Args>
-    static void create(Args&&... args)
+    static void set(Args&&... args)
     {
         static_assert(std::is_base_of_v<IAlicaLogger, LoggerType>, "LoggerType needs to inherit from IAlicaLogger");
-        if (_logger) {
-            _logger->log("Logger has already been created!", alica::Verbosity::WARNING);
-            return;
-        }
-
         _logger = std::make_unique<LoggerType>(std::forward<decltype(args)>(args)...);
     }
 
+    static void destroy();
     static IAlicaLogger* instance();
     static bool isInitialized();
 

--- a/alica_engine/src/engine/logging/AlicaDefaultLogger.cpp
+++ b/alica_engine/src/engine/logging/AlicaDefaultLogger.cpp
@@ -21,20 +21,21 @@ void AlicaDefaultLogger::log(const std::string& msg, Verbosity verbosity, const 
         return;
     }
 
+    std::ostringstream oss;
     if (verbosity < alica::Verbosity::WARNING) {
-        std::cout << _verbosityStringAndColorMap.at(verbosity).second << "[" << _verbosityStringAndColorMap.at(verbosity).first << "][" << _localAgentName
-                  << "]";
+        oss << _verbosityStringAndColorMap.at(verbosity).second << "[" << _verbosityStringAndColorMap.at(verbosity).first << "][" << _localAgentName << "]";
         if (!logSpace.empty()) {
-            std::cout << "[" << logSpace << "]";
+            oss << "[" << logSpace << "]";
         }
-        std::cout << ": " << msg << RESET << std::endl;
+        oss << ": " << msg << RESET << std::endl;
+        std::cout << oss.str();
     } else {
-        std::cerr << _verbosityStringAndColorMap.at(verbosity).second << "[" << _verbosityStringAndColorMap.at(verbosity).first << "][" << _localAgentName
-                  << "]";
+        oss << _verbosityStringAndColorMap.at(verbosity).second << "[" << _verbosityStringAndColorMap.at(verbosity).first << "][" << _localAgentName << "]";
         if (!logSpace.empty()) {
-            std::cerr << "[" << logSpace << "]";
+            oss << "[" << logSpace << "]";
         }
-        std::cerr << ": " << msg << RESET << std::endl;
+        oss << ": " << msg << RESET << std::endl;
+        std::cerr << oss.str();
     }
 }
 

--- a/alica_engine/src/engine/logging/AlicaLogger.cpp
+++ b/alica_engine/src/engine/logging/AlicaLogger.cpp
@@ -8,6 +8,11 @@ namespace alica
 {
 class IAlicaLogger;
 
+void AlicaLogger::destroy()
+{
+    _logger.reset();
+}
+
 IAlicaLogger* AlicaLogger::instance()
 {
     assert(_logger);

--- a/alica_tests/include/test_alica.h
+++ b/alica_tests/include/test_alica.h
@@ -336,7 +336,7 @@ protected:
 
 namespace alica::test
 {
-class SingleAgentTestFixture : public ::testing::Test
+class SingleAgentUninitializedTestFixture : public ::testing::Test
 {
 public:
     virtual void SetUp() override
@@ -347,13 +347,14 @@ public:
         path = THIS_PACKAGE_DIR;
         path += "/etc/";
 #endif
-        _tc = std::make_unique<TestContext>("hairy", std::vector<std::string>{path}, "Roleset", "TestMasterPlan", true, 1);
+        _tc = std::make_unique<TestContext>(agentName(), std::vector<std::string>{path}, "Roleset", "TestMasterPlan", true, 1);
         ASSERT_TRUE(_tc->isValid());
-        const YAML::Node& config = _tc->getConfig();
+    }
 
+    void initialize()
+    {
         _tc->setCommunicator<alicaDummyProxy::AlicaDummyCommunication>();
         _tc->setTimerFactory<alica::AlicaSystemTimerFactory>();
-        _tc->setLogger<alica::AlicaDefaultLogger>();
 
         AlicaCreators creators{std::make_unique<alica::DynamicConditionCreator>(), std::make_unique<alica::DynamicUtilityFunctionCreator>(),
                 std::make_unique<alica::DynamicConstraintCreator>(), std::make_unique<alica::DynamicBehaviourCreator>(),
@@ -366,9 +367,26 @@ public:
 
     virtual void TearDown() override {}
 
+    std::string agentName() const { return "hairy"; }
+
 protected:
     std::unique_ptr<TestContext> _tc;
 };
+
+class SingleAgentTestFixture : public SingleAgentUninitializedTestFixture
+{
+    using Base = SingleAgentUninitializedTestFixture;
+
+public:
+    virtual void SetUp() override
+    {
+        Base::SetUp();
+        Base::initialize();
+    }
+
+    virtual void TearDown() override { Base::TearDown(); }
+};
+
 } // namespace alica::test
 
 extern std::jmp_buf restore_point;

--- a/alica_tests/src/test/test_alica_logger.cpp
+++ b/alica_tests/src/test/test_alica_logger.cpp
@@ -2,25 +2,111 @@
 
 #include <gtest/gtest.h>
 
-namespace alica
+namespace alica::test
 {
 namespace
 {
 
-class AlicaDefaultLoggerTest : public AlicaTestFixture
+TEST_F(SingleAgentUninitializedTestFixture, noLoggerSet)
 {
-protected:
-    const char* getRoleSetName() const override { return "Roleset"; }
-    const char* getMasterPlanName() const override { return "SimpleTestPlan"; }
-    bool stepEngine() const override { return false; }
+    // check if logging is initialized even if the context is not yet initialized
+    ASSERT_TRUE(AlicaLogger::isInitialized());
+
+    // check if the logger is set to AlicaDefaultLogger
+    ASSERT_TRUE(dynamic_cast<AlicaDefaultLogger*>(AlicaLogger::instance()));
+}
+
+// A custom logger that stores the last log msg that was logged + the total number of logs. The logger is thread safe which indirectly verifies if a
+// non-copyable, non-movable class can be used as a logger
+class CustomLogger : public IAlicaLogger
+{
+public:
+    CustomLogger(Verbosity verbosity, const std::string& agentName, const std::string& customParam)
+            : _verbosity(verbosity)
+            , _agentName(agentName)
+            , _customParam(customParam)
+            , _numLogs(0)
+    {
+    }
+
+    bool verifyConstruction(Verbosity verbosity, const std::string& agentName, const std::string& customParam) const
+    {
+        return _verbosity == verbosity && _agentName == agentName && _customParam == customParam;
+    }
+
+    void log(const std::string& msg, Verbosity verbosity, const std::string& logSpace) override
+    {
+        std::unique_lock<std::mutex> lock(_logMutex);
+        _lastLogMsg = msg;
+        _lastLogVerbosity = verbosity;
+        _lastLogSpace = logSpace;
+        ++_numLogs;
+    }
+
+    bool verifyLog(const std::string& msg, Verbosity verbosity, const std::string& logSpace) const
+    {
+        std::unique_lock<std::mutex> lock(_logMutex);
+        return msg == _lastLogMsg && verbosity == _lastLogVerbosity && logSpace == _lastLogSpace;
+    }
+
+    std::size_t numLogs() const
+    {
+        std::unique_lock<std::mutex> lock(_logMutex);
+        return _numLogs;
+    }
+
+private:
+    // The constructor parameters
+    const Verbosity _verbosity;
+    const std::string _agentName;
+    const std::string _customParam;
+
+    // Info about the last log
+    mutable std::mutex _logMutex;
+    std::string _lastLogMsg;
+    Verbosity _lastLogVerbosity;
+    std::string _lastLogSpace;
+    std::size_t _numLogs;
 };
 
-TEST_F(AlicaDefaultLoggerTest, testSettingDefaultLogger)
+TEST_F(SingleAgentUninitializedTestFixture, loggerSet)
 {
-    ASSERT_NO_SIGNAL
-    // check that AlicaRosLogger is set.
-    alica::AlicaDefaultLogger* logger = dynamic_cast<alica::AlicaDefaultLogger*>(AlicaLogger::instance());
-    EXPECT_NE(logger, nullptr);
+    // check if a custom logger can be used
+
+    // set a custom logger
+    _tc->setLogger<CustomLogger>("custom_param");
+
+    // check if the logger is set to CustomLogger
+    ASSERT_TRUE(AlicaLogger::isInitialized());
+    auto customLogger = dynamic_cast<CustomLogger*>(AlicaLogger::instance());
+    ASSERT_TRUE(customLogger);
+
+    // check if the logger is constructed from the expected parameters
+    ASSERT_TRUE(customLogger->verifyConstruction(Verbosity::INFO, agentName(), "custom_param"));
+
+    // Try to log something & see if it works
+    Logging::log(Verbosity::ERROR, "log_space_log", "log_msg_log");
+    ASSERT_TRUE(customLogger->verifyLog("log_msg_log", Verbosity::ERROR, "log_space_log"));
+
+    // Use various log api's & see if they work
+    Logging::logDebug("log_space_debug") << "log_msg_debug";
+    ASSERT_TRUE(customLogger->verifyLog("log_msg_debug", Verbosity::DEBUG, "log_space_debug"));
+    Logging::logError("log_space_error") << "log_msg_error";
+    ASSERT_TRUE(customLogger->verifyLog("log_msg_error", Verbosity::ERROR, "log_space_error"));
+    Logging::logFatal("log_space_fatal") << "log_msg_fatal";
+    ASSERT_TRUE(customLogger->verifyLog("log_msg_fatal", Verbosity::FATAL, "log_space_fatal"));
+    Logging::logInfo("log_space_info") << "log_msg_info";
+    ASSERT_TRUE(customLogger->verifyLog("log_msg_info", Verbosity::INFO, "log_space_info"));
+    Logging::logWarn("log_space_warn") << "log_msg_warn";
+    ASSERT_TRUE(customLogger->verifyLog("log_msg_warn", Verbosity::WARNING, "log_space_warn"));
+
+    // Initialize the engine & check if some logs are added
+    auto numLogsBeforeInit = customLogger->numLogs();
+    initialize();
+    auto numLogsAfterInit = customLogger->numLogs();
+    ASSERT_EQ(customLogger, dynamic_cast<CustomLogger*>(AlicaLogger::instance()));
+    ASSERT_GE(numLogsAfterInit, numLogsBeforeInit);
 }
+
 } // namespace
-} // namespace alica
+} // namespace alica::test

--- a/supplementary/alica_ros1/supplementary_tests/src/test/test_alica_dynamicloadcreator.cpp
+++ b/supplementary/alica_ros1/supplementary_tests/src/test/test_alica_dynamicloadcreator.cpp
@@ -38,7 +38,7 @@ namespace
 class AlicaDynamicLoading : public ::testing::Test
 {
 public:
-    AlicaDynamicLoading() { AlicaLogger::create<alica::AlicaDefaultLogger>(Verbosity::DEBUG, "TEST"); }
+    AlicaDynamicLoading() { AlicaLogger::set<alica::AlicaDefaultLogger>(Verbosity::DEBUG, "TEST"); }
 
     std::string getRootPath() const
     {


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=1097473608

- Make AlicaDefaultLogger thread safe since it is the responsibility of the logging implementation

- Set the logger immediately on construction of the context so that it can be used to log messages during construction & before init() is called. This solves some obsure bugs where the logger was used before it was initialized in the context's set api's eg. setTraceFactory or the trace factory'sconstructor etc.

- Provides the ability to set the logger multiple times before the context is initialized which is consistent with other set api's

- Destroy the logger when the context is destroyed

- Add tests for custom logging & fix the test for default logging