### PR TITLE
Limit initial point loop iterations

### DIFF
--- a/supplementary/constraintsolver/package.xml
+++ b/supplementary/constraintsolver/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>constraintsolver</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>The constraintsolver package</description>
 
   <maintainer email="stephan.opfer@rapyuta-robotics.com">Stephan Opfer</maintainer>

--- a/supplementary/constraintsolver/src/GSolver.cpp
+++ b/supplementary/constraintsolver/src/GSolver.cpp
@@ -322,7 +322,7 @@ void GSolver::initialPoint(const autodiff::Tape& tape, ResultView o_res, const s
     bool found;
     // Give up if we can't find a valid initial value after 50 tries
     // Malformed constraints can lead to this situation
-    size_t maxIter = 50;
+    constexpr size_t maxIter = 50;
     size_t iter = 0;
     do {
         iter++;

--- a/supplementary/constraintsolver/src/GSolver.cpp
+++ b/supplementary/constraintsolver/src/GSolver.cpp
@@ -320,7 +320,12 @@ void GSolver::initialPoint(const autodiff::Tape& tape, ResultView o_res, const s
 {
     const int dim = o_res.dim();
     bool found;
+    // Give up if we can't find a valid initial value after 50 tries
+    // Malformed constraints can lead to this situation
+    size_t maxIter = 50;
+    size_t iter = 0;
     do {
+        iter++;
         for (int i = 0; i < dim; ++i) {
             o_res.editPoint()[i] = ((double) rand() / RAND_MAX) * limits[i].size() + limits[i].getMin();
         }
@@ -333,7 +338,7 @@ void GSolver::initialPoint(const autodiff::Tape& tape, ResultView o_res, const s
                 break;
             }
         }
-    } while (!found);
+    } while (!found && iter < maxIter);
     o_res.setUtil(o_value[0]);
 }
 
@@ -356,6 +361,12 @@ void GSolver::rPropLoop(const autodiff::Tape& tape, const double* seed, const st
         initialPointFromSeed(tape, seed, o_result, limits, curGradient);
     } else {
         initialPoint(tape, o_result, limits, curGradient);
+    }
+    for (int i = 1; i <= dim; ++i) {
+        if (std::isnan(curGradient[i])) {
+            o_result.setAborted();
+            return;
+        }
     }
 
     memcpy(formerGradient, curGradient, sizeof(double) * (dim + 1));


### PR DESCRIPTION
Depending on constraints it's possible that no valid initial point is found and this loop keeps running forever.
Add a simple iteration counter to prevent the endless loop.

Fixes https://www.wrike.com/open.htm?id=1236704894