### PR TITLE
Fix crash: dll access after its destruction

### DIFF
--- a/alica_dynamic_loading/include/DynamicBehaviourCreator.h
+++ b/alica_dynamic_loading/include/DynamicBehaviourCreator.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace alica
@@ -19,7 +20,14 @@ public:
 
 private:
     typedef std::unique_ptr<BasicBehaviour>(behaviourCreatorType)(BehaviourContext&);
-    std::function<behaviourCreatorType> _behaviourCreator;
+    /*
+     * Each symbol is stored in the map for 2 reasons:
+     * 1. The dll is unloaded when the last symbol from that dll is destructed so storing the symbols here is
+     * necessary so that the behaviour is not accessed after the dll is unloaded
+     * 2. The symbol is only loaded once (consequently the dll is also loaded only once) potentially improving performance
+     * by reducing repeated loads & unloads of the dll
+     */
+    std::unordered_map<std::string, std::function<behaviourCreatorType>> _behaviourCreatorMap;
     std::vector<std::string> _libraryPath;
 };
 

--- a/alica_dynamic_loading/include/DynamicConditionCreator.h
+++ b/alica_dynamic_loading/include/DynamicConditionCreator.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace alica
@@ -19,7 +20,7 @@ public:
 
 private:
     typedef std::shared_ptr<BasicCondition>(conditionCreatorType)(ConditionContext&);
-    std::function<conditionCreatorType> _conditionCreator;
+    std::unordered_map<std::string, std::function<conditionCreatorType>> _conditionCreatorMap; // see DynamicBehaviourCreator for an explanation
     std::vector<std::string> _libraryPath;
 };
 

--- a/alica_dynamic_loading/include/DynamicConstraintCreator.h
+++ b/alica_dynamic_loading/include/DynamicConstraintCreator.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace alica
@@ -19,7 +20,7 @@ public:
 
 private:
     typedef std::shared_ptr<BasicConstraint>(constraintCreatorType)(ConstraintContext&);
-    std::function<constraintCreatorType> _constraintCreator;
+    std::unordered_map<std::string, std::function<constraintCreatorType>> _constraintCreatorMap; // See DynamicBehaviourCreator for an explanation
     std::vector<std::string> _libraryPath;
 };
 

--- a/alica_dynamic_loading/include/DynamicPlanCreator.h
+++ b/alica_dynamic_loading/include/DynamicPlanCreator.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace alica
@@ -19,7 +20,7 @@ public:
 
 private:
     typedef std::unique_ptr<BasicPlan>(PlanCreatorType)(PlanContext&);
-    std::function<PlanCreatorType> _planCreator;
+    std::unordered_map<std::string, std::function<PlanCreatorType>> _planCreatorMap; // See DynamicBehaviourCreator for an explanation
     std::vector<std::string> _libraryPath;
 };
 

--- a/alica_dynamic_loading/include/DynamicTransitionConditionCreator.h
+++ b/alica_dynamic_loading/include/DynamicTransitionConditionCreator.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace alica
@@ -19,6 +20,7 @@ public:
 
 private:
     typedef bool(transitionConditionFunctionType)(const Blackboard*, const RunningPlan*, const Blackboard*);
+    std::unordered_map<std::string, TransitionConditionCallback> _transitionConditionMap; // See DynamicBehaviourCreator for an explanation
     std::vector<std::string> _libraryPath;
 };
 

--- a/alica_dynamic_loading/include/DynamicUtilityFunctionCreator.h
+++ b/alica_dynamic_loading/include/DynamicUtilityFunctionCreator.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace alica
@@ -19,7 +20,7 @@ public:
 
 private:
     typedef std::shared_ptr<BasicUtilityFunction>(utilityFunctionCreatorType)(UtilityFunctionContext&);
-    std::function<utilityFunctionCreatorType> _utilityFunctionCreator;
+    std::unordered_map<std::string, std::function<utilityFunctionCreatorType>> _utilityFunctionCreatorMap; // See DynamicBehaviourCreator for an explanation
     std::vector<std::string> _libraryPath;
 };
 

--- a/alica_dynamic_loading/src/DynamicTransitionConditionCreator.cpp
+++ b/alica_dynamic_loading/src/DynamicTransitionConditionCreator.cpp
@@ -24,14 +24,20 @@ TransitionConditionCallback DynamicTransitionConditionCreator::createConditions(
         throw DynamicLoadingException{"transitionCondition", conditionId, context.name, "", context.libraryName, ex.what()};
     }
 
+    std::string completeSymbolName = completeLibraryName + context.name;
+    if (auto it = _transitionConditionMap.find(completeSymbolName); it != _transitionConditionMap.end()) {
+        return it->second;
+    }
+
     try {
-        auto fun = boost::dll::import_alias<transitionConditionFunctionType>( // type of imported symbol must be explicitly specified
-                completeLibraryName,                                          // complete path to library also with file name
-                context.name,                                                 // symbol to import
-                boost::dll::load_mode::append_decorations                     // do append extensions and prefixes
-        );
+        _transitionConditionMap[completeSymbolName] =
+                boost::dll::import_alias<transitionConditionFunctionType>( // type of imported symbol must be explicitly specified
+                        completeLibraryName,                               // complete path to library also with file name
+                        context.name,                                      // symbol to import
+                        boost::dll::load_mode::append_decorations          // do append extensions and prefixes
+                );
         Logging::logDebug("DynamicLoading") << "Loaded transition condition " << context.name;
-        return fun;
+        return _transitionConditionMap.at(completeSymbolName);
     } catch (const std::exception& ex) {
         throw DynamicLoadingException{"transitionCondition", conditionId, context.name, "", context.libraryName, ex.what()};
     }


### PR DESCRIPTION
The dynamic creators maintain a reference to the currently loaded symbol, therefore dlls that were loaded prior would no longer be loaded & accessing such dlls (typically in the destructor of the beh/plan etc) would cause undefined behaviour. Specifically this lead to a crash in the destructor of the GoTo behaviour in turtlesim. Such crashes are hard to debug & can occur in more ways due to this issue. As a fix, the creator for each symbol is stored for the lifetime of the dynamic creator object itself which is basically the entire duration of the engine. Consequently the symbol & dll is loaded just once potentially improving performance.