### PR TITLE
Fix segfault on behaviour's result update

### DIFF
--- a/alica_engine/include/engine/BasicBehaviour.h
+++ b/alica_engine/include/engine/BasicBehaviour.h
@@ -106,6 +106,8 @@ private:
         FAILURE
     };
 
+    static std::string resultToString(BehResult result);
+
     void doInit() override;
     void doRun() override;
     void doTerminate() override;

--- a/alica_engine/src/engine/BasicBehaviour.cpp
+++ b/alica_engine/src/engine/BasicBehaviour.cpp
@@ -66,8 +66,26 @@ void BasicBehaviour::doRun()
     }
 }
 
+std::string BasicBehaviour::resultToString(BehResult result)
+{
+    switch (result) {
+    case BehResult::SUCCESS:
+        return "Success";
+    case BehResult::FAILURE:
+        return "Failure";
+    case BehResult::UNKNOWN:
+        return "Unknown";
+    }
+    return ""; // should never reach
+}
+
 void BasicBehaviour::doTerminate()
 {
+    if (getTrace()) {
+        const std::string resultStr = resultToString(_behResult.load());
+        Logging::logInfo(LOGNAME) << "Behaviour: " << getName() << ", result: " << resultStr;
+        getTrace()->setTag("Result", resultStr);
+    }
     try {
         onTermination();
     } catch (...) {
@@ -91,11 +109,6 @@ void BasicBehaviour::setResult(BehResult result)
     auto prev = _behResult.exchange(result);
     if (prev != result) {
         _planBase->addFastPathEvent(getPlanContext());
-        if (getTrace()) {
-            const char* resultStr = (result == BehResult::SUCCESS ? "Success" : "Fail");
-            Logging::logInfo(LOGNAME) << "Behaviour: " << getName() << ", result: " << resultStr;
-            getTrace()->setTag("Result", resultStr);
-        }
     }
 }
 


### PR DESCRIPTION
setSuccess or setFailure can be set by alica's user concurrently with alica engine getting it, which means that if beh result changed to success, trace can be destroyed, thus we receive segfault when accessing trace inside setting result