### PR TITLE
Expand interface to support trace links

### DIFF
--- a/alica_engine/include/engine/BasicBehaviour.h
+++ b/alica_engine/include/engine/BasicBehaviour.h
@@ -84,7 +84,7 @@ protected:
 
     AgentId getOwnId() const;
 
-    void setTracing(TracingType type, std::function<std::optional<std::string>(const BasicBehaviour*)> customTraceContextGetter = {})
+    void setTracing(TracingType type, std::function<tracing::SpanStartOptions(const BasicBehaviour*)> customTraceContextGetter = {})
     {
         if (customTraceContextGetter) {
             RunnableObject::setTracing(
@@ -93,7 +93,14 @@ protected:
             RunnableObject::setTracing(type, {});
         }
     }
-
+    void setTracing(TracingType type, std::function<std::optional<std::string>(const BasicBehaviour*)> customTraceContextGetter)
+    {
+        setTracing(type, [this, inner = std::move(customTraceContextGetter)](const BasicBehaviour*) {
+            tracing::SpanStartOptions options;
+            options.parentContext = inner(this);
+            return options;
+        });
+    }
     void setSuccess();
     void setFailure();
 

--- a/alica_engine/include/engine/BasicPlan.h
+++ b/alica_engine/include/engine/BasicPlan.h
@@ -53,7 +53,7 @@ public:
 protected:
     using RunnableObject::getTraceFactory;
 
-    void setTracing(TracingType type, std::function<std::optional<std::string>(const BasicPlan*)> customTraceContextGetter = {})
+    void setTracing(TracingType type, std::function<tracing::SpanStartOptions(const BasicPlan*)> customTraceContextGetter = {})
     {
         if (customTraceContextGetter) {
             RunnableObject::setTracing(
@@ -61,6 +61,14 @@ protected:
         } else {
             RunnableObject::setTracing(type, {});
         }
+    }
+    void setTracing(TracingType type, std::function<std::optional<std::string>(const BasicPlan*)> customTraceContextGetter)
+    {
+        setTracing(type, [this, inner = std::move(customTraceContextGetter)](const BasicPlan*) -> tracing::SpanStartOptions {
+            tracing::SpanStartOptions options;
+            options.parentContext = inner(this);
+            return options;
+        });
     }
 
     virtual void onInit(){};

--- a/alica_engine/include/engine/IAlicaTrace.h
+++ b/alica_engine/include/engine/IAlicaTrace.h
@@ -58,23 +58,31 @@ protected:
     }
 };
 
-class SpanLink
+namespace tracing
 {
-public:
+struct SpanLink
+{
     std::string context;
     // Warning:  Ensure string_views in attributes are valid for the lifetime of the span link
     std::unordered_map<std::string, IAlicaTrace::TraceValue> attributes;
 };
+
+struct SpanStartOptions
+{
+    std::optional<std::string> parentContext;
+    std::vector<SpanLink> links;
+};
+} // namespace tracing
 
 class IAlicaTraceFactory
 {
 public:
     // Two argument version of create.  Deprecated.
     virtual std::unique_ptr<IAlicaTrace> create(const std::string& opName, std::optional<const std::string> parent = std::nullopt) const { return nullptr; }
-    virtual std::unique_ptr<IAlicaTrace> create(const std::string& opName, std::optional<const std::string> parent_context, const std::vector<SpanLink>&) const
+    virtual std::unique_ptr<IAlicaTrace> create(const std::string& opName, const tracing::SpanStartOptions& options) const
     {
         // Concrete implementation provided for backwards compatibility
-        return nullptr;
+        return create(opName, options.parentContext);
     }
     virtual void setGlobalContext(const std::string& globalContext) = 0;
     virtual void unsetGlobalContext() = 0;

--- a/alica_engine/include/engine/IAlicaTrace.h
+++ b/alica_engine/include/engine/IAlicaTrace.h
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace alica
 {
@@ -57,10 +58,24 @@ protected:
     }
 };
 
+class SpanLink
+{
+public:
+    std::string context;
+    // Warning:  Ensure string_views in attributes are valid for the lifetime of the span link
+    std::unordered_map<std::string, IAlicaTrace::TraceValue> attributes;
+};
+
 class IAlicaTraceFactory
 {
 public:
-    virtual std::unique_ptr<IAlicaTrace> create(const std::string& opName, std::optional<const std::string> parent = std::nullopt) const = 0;
+    // Two argument version of create.  Deprecated.
+    virtual std::unique_ptr<IAlicaTrace> create(const std::string& opName, std::optional<const std::string> parent = std::nullopt) const { return nullptr; }
+    virtual std::unique_ptr<IAlicaTrace> create(const std::string& opName, std::optional<const std::string> parent_context, const std::vector<SpanLink>&) const
+    {
+        // Concrete implementation provided for backwards compatibility
+        return nullptr;
+    }
     virtual void setGlobalContext(const std::string& globalContext) = 0;
     virtual void unsetGlobalContext() = 0;
     virtual ~IAlicaTraceFactory() = default;

--- a/alica_engine/include/engine/IAlicaTrace.h
+++ b/alica_engine/include/engine/IAlicaTrace.h
@@ -33,7 +33,7 @@ public:
         {
         }
 
-        const Variant variant;
+        Variant variant;
     };
 
 public:

--- a/alica_engine/include/engine/IAlicaTrace.h
+++ b/alica_engine/include/engine/IAlicaTrace.h
@@ -35,8 +35,7 @@ public:
         {
         }
 
-    private:
-        Variant variant;
+        const Variant variant;
     };
 
 public:

--- a/alica_engine/include/engine/IAlicaTrace.h
+++ b/alica_engine/include/engine/IAlicaTrace.h
@@ -24,8 +24,6 @@ class IAlicaTrace
 public:
     class TraceValue
     {
-        friend IAlicaTrace;
-
         using Variant = std::variant<bool, long long int, unsigned long long int, double, std::string_view>;
 
     public:
@@ -48,13 +46,6 @@ public:
     // leave the trace in a valid but unspecified state. Calling context on a finished trace is a valid operation
     virtual void finish() = 0;
     virtual std::string context() const = 0;
-
-protected:
-    template <typename V>
-    static decltype(auto) extractVariant(V&& trace_value)
-    {
-        return (std::forward<V>(trace_value).variant);
-    }
 };
 
 namespace tracing

--- a/alica_engine/include/engine/RunnableObject.h
+++ b/alica_engine/include/engine/RunnableObject.h
@@ -58,7 +58,7 @@ public:
 
     // Set the tracing type for this runnable object. customTraceContextGetter is required for custom tracing
     // & this method will be called to get the parent trace context before initialiseParameters is called
-    void setTracing(TracingType type, std::function<std::optional<std::string>()> customTraceContextGetter = {});
+    void setTracing(TracingType type, std::function<tracing::SpanStartOptions()> customTraceContextGetter = {});
     void setupTraceContext(const std::string& name, RunningPlan* rp);
     void cleanupTraceContext();
     void traceInitCall();
@@ -72,7 +72,7 @@ private:
     TracingType _tracingType;
     bool _runTraced; // True if the behaviour/plan's run method has already been logged in the trace
     const IAlicaTraceFactory* _tf;
-    std::function<std::optional<std::string>()> _customTraceContextGetter;
+    std::function<tracing::SpanStartOptions()> _customTraceContextGetter;
     std::unique_ptr<IAlicaTrace> _trace;
     const std::string& _name;
 };
@@ -94,10 +94,11 @@ protected:
     virtual void doRun() = 0;
     virtual void doTerminate() = 0;
 
-    void setTracing(TracingType type, std::function<std::optional<std::string>()> customTraceContextGetter = {})
+    void setTracing(TracingType type, std::function<tracing::SpanStartOptions()> customTraceContextGetter = {})
     {
         _runnableObjectTracer.setTracing(type, customTraceContextGetter);
     }
+
     const std::string& getName() const { return _name; };
     IAlicaTrace* getTrace() const { return _runnableObjectTracer.getTrace(); };
     // Helper to allow applications to generate their own trace.

--- a/alica_engine/src/engine/RunnableObject.cpp
+++ b/alica_engine/src/engine/RunnableObject.cpp
@@ -168,7 +168,7 @@ void RunnableObject::handleException(const std::string& exceptionOriginMethod, s
 }
 
 // Tracing methods
-void TraceRunnableObject::setTracing(TracingType type, std::function<std::optional<std::string>()> customTraceContextGetter)
+void TraceRunnableObject::setTracing(TracingType type, std::function<tracing::SpanStartOptions()> customTraceContextGetter)
 {
     _tracingType = type;
     _customTraceContextGetter = std::move(customTraceContextGetter);

--- a/alica_tests/include/alica_tests/TestTracing.h
+++ b/alica_tests/include/alica_tests/TestTracing.h
@@ -62,7 +62,7 @@ private:
                     ss << v;
                     return std::move(ss).str();
                 },
-                extractVariant(val));
+                val.variant);
     }
 };
 

--- a/supplementary/alica_tracing/src/tracing/Trace.cpp
+++ b/supplementary/alica_tracing/src/tracing/Trace.cpp
@@ -57,7 +57,7 @@ Trace::~Trace()
 
 void Trace::setTag(std::string_view key, TraceValue value)
 {
-    _rawTrace->SetTag(prepareStringView(key), prepareRawTraceValue(extractVariant(std::move(value))));
+    _rawTrace->SetTag(prepareStringView(key), prepareRawTraceValue(std::move(value).variant));
 }
 
 void Trace::setTag(const std::string& key, const RawTraceValue& value)
@@ -71,7 +71,7 @@ void Trace::log(const std::unordered_map<std::string_view, TraceValue>& fields)
     RawFields raw_fields;
     raw_fields.reserve(fields.size());
     std::transform(begin(fields), end(fields), std::back_inserter(raw_fields),
-            [](const auto& v) { return std::make_pair(prepareStringView(v.first), prepareRawTraceValue(extractVariant(v.second))); });
+            [](const auto& v) { return std::make_pair(prepareStringView(v.first), prepareRawTraceValue(v.second.variant)); });
     _rawTrace->Log(opentracing::SystemClock::now(), raw_fields);
 }
 

--- a/supplementary/alica_tracing/src/tracing/Trace.cpp
+++ b/supplementary/alica_tracing/src/tracing/Trace.cpp
@@ -57,7 +57,7 @@ Trace::~Trace()
 
 void Trace::setTag(std::string_view key, TraceValue value)
 {
-    _rawTrace->SetTag(prepareStringView(key), prepareRawTraceValue(std::move(value).variant));
+    _rawTrace->SetTag(prepareStringView(key), prepareRawTraceValue(std::move(value.variant)));
 }
 
 void Trace::setTag(const std::string& key, const RawTraceValue& value)


### PR DESCRIPTION
Opentelemetry supports indirect links to other spans.  Expand the interface to support this, with backwards compatibility.