### PR TITLE
Add ability to set keys on the global blackboard

### DIFF
--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -23,6 +23,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <engine/blackboard/BlackboardBlueprint.h>
 #include <memory>
 #include <optional>
 #include <string>
@@ -302,8 +303,10 @@ public:
      *
      * @return A reference to the global blackboard
      */
-    const Blackboard& getGlobalBlackboard() const;
-    Blackboard& editGlobalBlackboard();
+    [[deprecated("call std::shared_ptr<Blackboard> getGlobalBlackboard() instead")]] const Blackboard& getGlobalBlackboard() const;
+    [[deprecated("call std::shared_ptr<Blackboard> getGlobalBlackboard() instead")]] Blackboard& editGlobalBlackboard();
+
+    const std::shared_ptr<Blackboard> getGlobalBlackboardShared();
 
     /**
      * Add a solver to be used by this alica instance.
@@ -474,6 +477,7 @@ private:
     static const std::unordered_map<std::string, Verbosity> _verbosityStringToVerbosityMap;
 
     bool _initialized = false;
+    std::shared_ptr<Blackboard> _globalBlackboard;
 
     /**
      * Initializes yaml configuration.
@@ -503,7 +507,10 @@ private:
      */
     AlicaCommunicationHandlers getCommunicationHandlers();
 
-    Blackboard _globalBlackboard;
+    /*
+     * Load the global blackoard blueprint
+     */
+    std::unique_ptr<BlackboardBlueprint> loadGlobalBlackboardBlueprint();
 };
 
 template <class ClockType, class... Args>

--- a/alica_engine/include/engine/AlicaContext.h
+++ b/alica_engine/include/engine/AlicaContext.h
@@ -303,8 +303,8 @@ public:
      *
      * @return A reference to the global blackboard
      */
-    [[deprecated("call std::shared_ptr<Blackboard> getGlobalBlackboard() instead")]] const Blackboard& getGlobalBlackboard() const;
-    [[deprecated("call std::shared_ptr<Blackboard> getGlobalBlackboard() instead")]] Blackboard& editGlobalBlackboard();
+    [[deprecated("call std::shared_ptr<Blackboard> getGlobalBlackboardShared() instead")]] const Blackboard& getGlobalBlackboard() const;
+    [[deprecated("call std::shared_ptr<Blackboard> getGlobalBlackboardShared() instead")]] Blackboard& editGlobalBlackboard();
 
     const std::shared_ptr<Blackboard> getGlobalBlackboardShared();
 

--- a/alica_engine/include/engine/AlicaEngine.h
+++ b/alica_engine/include/engine/AlicaEngine.h
@@ -80,8 +80,7 @@ public:
     const TeamObserver& getTeamObserver() const { return _teamObserver; }
     TeamObserver& editTeamObserver() { return _teamObserver; }
 
-    const Blackboard& getGlobalBlackboard() const { return _ctx.getGlobalBlackboard(); }
-    Blackboard& editGlobalBlackboard() { return _ctx.editGlobalBlackboard(); }
+    const std::shared_ptr<Blackboard> getGlobalBlackboard() { return _ctx.getGlobalBlackboardShared(); }
 
     // Data Access:
     const RoleSet* getRoleSet() const { return _roleSet; }

--- a/alica_engine/include/engine/BasicBehaviour.h
+++ b/alica_engine/include/engine/BasicBehaviour.h
@@ -25,7 +25,7 @@ class EntryPoint;
 
 struct BehaviourContext
 {
-    Blackboard& globalBlackboard;
+    std::shared_ptr<Blackboard> globalBlackboard;
     const std::string name;
     const Behaviour* behaviourModel;
     const IAlicaTraceFactory* traceFactory;

--- a/alica_engine/include/engine/BasicPlan.h
+++ b/alica_engine/include/engine/BasicPlan.h
@@ -71,9 +71,9 @@ protected:
         });
     }
 
-    virtual void onInit() {};
-    virtual void run() {};
-    virtual void onTerminate() {};
+    virtual void onInit(){};
+    virtual void run(){};
+    virtual void onTerminate(){};
 
 private:
     void doInit() override;

--- a/alica_engine/include/engine/BasicPlan.h
+++ b/alica_engine/include/engine/BasicPlan.h
@@ -16,7 +16,7 @@ class Transition;
 
 struct PlanContext
 {
-    Blackboard& globalBlackboard;
+    std::shared_ptr<Blackboard> globalBlackboard;
     const std::string name;
     const Plan* planModel;
     const IAlicaTraceFactory* traceFactory;
@@ -71,9 +71,9 @@ protected:
         });
     }
 
-    virtual void onInit(){};
-    virtual void run(){};
-    virtual void onTerminate(){};
+    virtual void onInit() {};
+    virtual void run() {};
+    virtual void onTerminate() {};
 
 private:
     void doInit() override;

--- a/alica_engine/include/engine/PlanBase.h
+++ b/alica_engine/include/engine/PlanBase.h
@@ -46,7 +46,7 @@ class PlanBase
 public:
     PlanBase(ConfigChangeListener& configChangeListener, const AlicaClock& clock, const IAlicaCommunication& communicator, IRoleAssignment& roleAssignment,
             SyncModule& syncModule, AuthorityManager& authorityManager, TeamObserver& teamObserver, TeamManager& teamManager,
-            const PlanRepository& planRepository, std::atomic<bool>& stepEngine, std::atomic<bool>& stepCalled, Blackboard& globalBlackboard,
+            const PlanRepository& planRepository, std::atomic<bool>& stepEngine, std::atomic<bool>& stepCalled, std::shared_ptr<Blackboard> globalBlackboard,
             VariableSyncModule& resultStore, const std::unordered_map<size_t, std::unique_ptr<ISolverBase>>& solvers, const IAlicaTimerFactory& timerFactory,
             const IAlicaTraceFactory* traceFactory);
     ~PlanBase();
@@ -95,7 +95,7 @@ private:
     const PlanRepository& _planRepository;
     std::atomic<bool>& _stepEngine;
     std::atomic<bool>& _stepCalled;
-    Blackboard& _globalBlackboard;
+    std::shared_ptr<Blackboard> _globalBlackboard;
     RuntimePlanFactory _runTimePlanFactory;
     RuntimeBehaviourFactory _runTimeBehaviourFactory;
     VariableSyncModule& _resultStore;

--- a/alica_engine/include/engine/RuleBook.h
+++ b/alica_engine/include/engine/RuleBook.h
@@ -43,7 +43,7 @@ public:
     void resetChangeOccurred() { _changeOccurred = false; }
     PlanSelector* getPlanSelector() const { return _ps.get(); }
     void reload(const YAML::Node& config);
-    void init(const Blackboard* globalBlackboard);
+    void init(std::shared_ptr<const Blackboard> globalBlackboard);
 
 private:
     static constexpr const char* LOGNAME = "Rulebook";
@@ -56,7 +56,7 @@ private:
     int _maxConsecutiveChanges;
     bool _autoFailureHandlingEnabled;
     bool _changeOccurred;
-    const Blackboard* _globalBlackboard;
+    std::shared_ptr<const Blackboard> _globalBlackboard;
 
     PlanChange synchTransitionRule(RunningPlan& rp);
     PlanChange transitionRule(RunningPlan& r);

--- a/alica_engine/include/engine/RunnableObject.h
+++ b/alica_engine/include/engine/RunnableObject.h
@@ -85,7 +85,7 @@ class RunnableObject
 protected:
     using TracingType = TraceRunnableObject::TracingType;
 
-    RunnableObject(Blackboard& globalBlackboard, const IAlicaTraceFactory* tf, const std::string& name = "");
+    RunnableObject(std::shared_ptr<Blackboard> globalBlackboard, const IAlicaTraceFactory* tf, const std::string& name = "");
     virtual ~RunnableObject() = default;
 
     static constexpr int DEFAULT_MS_INTERVAL = 100;
@@ -108,7 +108,7 @@ protected:
     RunningPlan* getPlanContext() const { return _runningplanContext; }
     const std::shared_ptr<Blackboard> getBlackboard() { return _blackboard; }
     const BlackboardBlueprint* getBlackboardBlueprint() const { return _blackboardBlueprint; }
-    Blackboard* getGlobalBlackboard() { return &_globalBlackboard; };
+    const std::shared_ptr<Blackboard> getGlobalBlackboard() { return _globalBlackboard; };
 
     void start(RunningPlan* rp);
     void stop();
@@ -149,7 +149,7 @@ private:
     std::unique_ptr<IAlicaTimer> _activeRunTimer;
     const BlackboardBlueprint* _blackboardBlueprint;
     std::shared_ptr<Blackboard> _blackboard;
-    Blackboard& _globalBlackboard;
+    std::shared_ptr<Blackboard> _globalBlackboard;
 
     // Map from ConfAbstractPlanWrapper id to associated attachment
     // Only plan will have these

--- a/alica_engine/include/engine/RunningPlan.h
+++ b/alica_engine/include/engine/RunningPlan.h
@@ -102,11 +102,11 @@ public:
         bool allocationNeeded;
         mutable std::atomic<EvalStatus> runTimeConditionStatus;
     };
-    explicit RunningPlan(ConfigChangeListener& configChangeListener, const AlicaClock& clock, const Blackboard& globalBlackboard,
+    explicit RunningPlan(ConfigChangeListener& configChangeListener, const AlicaClock& clock, std::shared_ptr<const Blackboard> globalBlackboard,
             const RuntimePlanFactory& runTimePlanFactory, TeamObserver& teamObserver, TeamManager& teamManager, const PlanRepository& planRepository,
             VariableSyncModule& resultStore, const std::unordered_map<size_t, std::unique_ptr<ISolverBase>>& solvers);
-    RunningPlan(ConfigChangeListener& configChangeListener, const AlicaClock& clock, const Blackboard& globalBlackboard, TeamObserver& teamObserver,
-            TeamManager& teamManager, const PlanRepository& planRepository, VariableSyncModule& resultStore,
+    RunningPlan(ConfigChangeListener& configChangeListener, const AlicaClock& clock, std::shared_ptr<const Blackboard> globalBlackboard,
+            TeamObserver& teamObserver, TeamManager& teamManager, const PlanRepository& planRepository, VariableSyncModule& resultStore,
             const std::unordered_map<size_t, std::unique_ptr<ISolverBase>>& solvers, const RuntimePlanFactory& runTimePlanFactory,
             const RuntimeBehaviourFactory& runTimeBehaviourFactory, const AbstractPlan* abstractPlan, const ConfAbstractPlanWrapper* wrapper);
     static void init(const YAML::Node& config);
@@ -262,7 +262,7 @@ private:
 
     // engine Pointer
     const AlicaClock& _clock;
-    const Blackboard& _globalBlackboard;
+    std::shared_ptr<const Blackboard> _globalBlackboard;
     const RuntimePlanFactory& _runTimePlanFactory;
     TeamObserver& _teamObserver;
     TeamManager& _teamManager;

--- a/alica_engine/include/engine/RuntimeBehaviourFactory.h
+++ b/alica_engine/include/engine/RuntimeBehaviourFactory.h
@@ -24,8 +24,8 @@ class IAlicaTimerFactory;
 class RuntimeBehaviourFactory
 {
 public:
-    RuntimeBehaviourFactory(Blackboard& globalBlackboard, TeamManager& teamManager, PlanBase& planBase, const IAlicaCommunication& communication,
-            const IAlicaTraceFactory* traceFactory, const IAlicaTimerFactory& timerFactory);
+    RuntimeBehaviourFactory(std::shared_ptr<Blackboard> globalBlackboard, TeamManager& teamManager, PlanBase& planBase,
+            const IAlicaCommunication& communication, const IAlicaTraceFactory* traceFactory, const IAlicaTimerFactory& timerFactory);
     ~RuntimeBehaviourFactory() = default;
     void init(std::unique_ptr<IBehaviourCreator>&& bc);
 
@@ -33,7 +33,7 @@ public:
 
 private:
     std::unique_ptr<IBehaviourCreator> _creator;
-    Blackboard& _globalBlackboard;
+    std::shared_ptr<Blackboard> _globalBlackboard;
     TeamManager& _teamManager;
     PlanBase& _planBase;
     const IAlicaCommunication& _communication;

--- a/alica_engine/include/engine/RuntimePlanFactory.h
+++ b/alica_engine/include/engine/RuntimePlanFactory.h
@@ -20,8 +20,8 @@ class IAlicaTimerFactory;
 class RuntimePlanFactory
 {
 public:
-    RuntimePlanFactory(
-            Blackboard& globalBlackboard, const IAlicaTraceFactory* traceFactory, const TeamManager& teamManager, const IAlicaTimerFactory& timerFactory);
+    RuntimePlanFactory(std::shared_ptr<Blackboard> globalBlackboard, const IAlicaTraceFactory* traceFactory, const TeamManager& teamManager,
+            const IAlicaTimerFactory& timerFactory);
     ~RuntimePlanFactory() = default;
     void init(std::unique_ptr<IPlanCreator>&& pc);
 
@@ -29,7 +29,7 @@ public:
 
 private:
     std::unique_ptr<IPlanCreator> _creator;
-    Blackboard& _globalBlackboard;
+    std::shared_ptr<Blackboard> _globalBlackboard;
     const IAlicaTraceFactory* _traceFactory;
     const TeamManager& _teamManager;
     const IAlicaTimerFactory& _timerFactory;

--- a/alica_engine/include/engine/blackboard/Blackboard.h
+++ b/alica_engine/include/engine/blackboard/Blackboard.h
@@ -63,8 +63,14 @@ public:
                 typeIndex = BB_VALUE_TYPE_ANY_INDEX;
             }
             try {
-                // insert a default constructed value
-                _vals.emplace(std::piecewise_construct, std::forward_as_tuple(key), std::forward_as_tuple(makeBBValueForIndex<false>::make(typeIndex.value())));
+                // insert a default constructed value or construct from the specified default value for the key
+                if (keyInfo.defaultValue.empty()) {
+                    _vals.emplace(
+                            std::piecewise_construct, std::forward_as_tuple(key), std::forward_as_tuple(makeBBValueForIndex<false>::make(typeIndex.value())));
+                } else {
+                    _vals.emplace(std::piecewise_construct, std::forward_as_tuple(key),
+                            std::forward_as_tuple(makeBBValueForIndex<true>::make(typeIndex.value(), keyInfo.defaultValue)));
+                }
             } catch (const std::exception& ex) {
                 throw BlackboardException(stringify("Could not initialize key: ", key, " with value of type: ", keyInfo.type, ", details: ", ex.what()));
             }

--- a/alica_engine/include/engine/blackboard/BlackboardBlueprint.h
+++ b/alica_engine/include/engine/blackboard/BlackboardBlueprint.h
@@ -14,14 +14,15 @@ class BlackboardBlueprint
     {
         std::string type;
         std::string access;
+        std::string defaultValue;
     };
 
 public:
     using const_iterator = std::unordered_map<std::string, KeyInfo>::const_iterator;
 
-    void addKey(const std::string& key, const std::string& type, const std::string& access)
+    void addKey(const std::string& key, const std::string& type, const std::string& access, const std::string& defaultValue = std::string{})
     {
-        _keyInfo.emplace(std::piecewise_construct, std::forward_as_tuple(key), std::forward_as_tuple(KeyInfo{type, access}));
+        _keyInfo.emplace(std::piecewise_construct, std::forward_as_tuple(key), std::forward_as_tuple(KeyInfo{type, access, defaultValue}));
     }
     const_iterator begin() const { return _keyInfo.begin(); }
     const_iterator end() const { return _keyInfo.end(); }

--- a/alica_engine/include/engine/model/Condition.h
+++ b/alica_engine/include/engine/model/Condition.h
@@ -41,7 +41,7 @@ public:
 
     const std::shared_ptr<BasicCondition>& getBasicCondition() const { return _basicCondition; }
 
-    bool evaluate(const RunningPlan& rp, const Blackboard* globalBlackboard) const;
+    bool evaluate(const RunningPlan& rp, std::shared_ptr<const Blackboard> globalBlackboard) const;
 
     std::string getLibraryName() const;
 

--- a/alica_engine/include/engine/modelmanagement/Strings.h
+++ b/alica_engine/include/engine/modelmanagement/Strings.h
@@ -96,6 +96,7 @@ static const std::string normalStateType = "State";
 static const std::string isSuccessState = "success";
 static const std::string inheritBlackboard = "inheritBlackboard";
 static const std::string key = "key";
+static const std::string defaultValue = "defaultValue";
 static const std::string transitionCondition = "transitionCondition";
 static const std::string transitionConditionRepository = "transitionConditionRepository";
 static const std::string libraryName = "libraryName";

--- a/alica_engine/include/engine/planselector/PlanSelector.h
+++ b/alica_engine/include/engine/planselector/PlanSelector.h
@@ -29,7 +29,7 @@ public:
 
     RunningPlan* createRunningPlan(RunningPlan* planningParent, const PlanGrp& plans, const AgentGrp& robotIDs, const RunningPlan* oldRp,
             const PlanType* relevantPlanType, double& o_oldUtility, const ConfAbstractPlanWrapper* wrapper);
-    void setGlobalBlackboard(const Blackboard* globalBlackboard);
+    void setGlobalBlackboard(std::shared_ptr<const Blackboard> globalBlackboard);
 
 private:
     static constexpr const char* LOGNAME = "PlanSelector";

--- a/alica_engine/src/engine/AlicaEngine.cpp
+++ b/alica_engine/src/engine/AlicaEngine.cpp
@@ -44,7 +44,7 @@ AlicaEngine::AlicaEngine(AlicaContext& ctx, YAML::Node& config, const AlicaConte
         , _variableSyncModule(std::make_unique<VariableSyncModule>(
                   _configChangeListener, _ctx.getCommunicator(), _ctx.getAlicaClock(), editTeamManager(), _ctx.getTimerFactory()))
         , _planBase(_configChangeListener, _ctx.getAlicaClock(), _ctx.getCommunicator(), editRoleAssignment(), editSyncModul(), editAuth(), editTeamObserver(),
-                  editTeamManager(), getPlanRepository(), _stepEngine, _stepCalled, editGlobalBlackboard(), editResultStore(), _ctx.getSolvers(),
+                  editTeamManager(), getPlanRepository(), _stepEngine, _stepCalled, getGlobalBlackboard(), editResultStore(), _ctx.getSolvers(),
                   getTimerFactory(), getTraceFactory())
 {
     auto reloadFunctionPtr = std::bind(&AlicaEngine::reload, this, std::placeholders::_1);

--- a/alica_engine/src/engine/PlanBase.cpp
+++ b/alica_engine/src/engine/PlanBase.cpp
@@ -31,7 +31,7 @@ namespace alica
  */
 PlanBase::PlanBase(ConfigChangeListener& configChangeListener, const AlicaClock& clock, const IAlicaCommunication& communicator,
         IRoleAssignment& roleAssignment, SyncModule& syncModule, AuthorityManager& authorityManager, TeamObserver& teamObserver, TeamManager& teamManager,
-        const PlanRepository& planRepository, std::atomic<bool>& stepEngine, std::atomic<bool>& stepCalled, Blackboard& globalBlackboard,
+        const PlanRepository& planRepository, std::atomic<bool>& stepEngine, std::atomic<bool>& stepCalled, std::shared_ptr<Blackboard> globalBlackboard,
         VariableSyncModule& resultStore, const std::unordered_map<size_t, std::unique_ptr<ISolverBase>>& solvers, const IAlicaTimerFactory& timerFactory,
         const IAlicaTraceFactory* traceFactory)
         : _configChangeListener(configChangeListener)
@@ -117,7 +117,7 @@ void PlanBase::reload(const YAML::Node& config)
  */
 void PlanBase::start(const Plan* masterPlan)
 {
-    _ruleBook.init(&_globalBlackboard);
+    _ruleBook.init(_globalBlackboard);
     if (!_running) {
         _running = true;
         if (_statusMessage) {

--- a/alica_engine/src/engine/RuleBook.cpp
+++ b/alica_engine/src/engine/RuleBook.cpp
@@ -181,8 +181,9 @@ PlanChange RuleBook::dynamicAllocationRule(RunningPlan& r)
             r.setAllocationNeeded(true);
         }
 
-        Logging::logInfo(LOGNAME) << "B4 dynChange: Util is " << curUtil << " | " << " suggested is " << possibleUtil << " | " << " threshold "
-                                  << p->getUtilityThreshold() << "\n"
+        Logging::logInfo(LOGNAME) << "B4 dynChange: Util is " << curUtil << " | "
+                                  << " suggested is " << possibleUtil << " | "
+                                  << " threshold " << p->getUtilityThreshold() << "\n"
                                   << "DynAlloc in " << p->getName();
 
         return PlanChange::InternalChange;

--- a/alica_engine/src/engine/RuleBook.cpp
+++ b/alica_engine/src/engine/RuleBook.cpp
@@ -44,7 +44,7 @@ RuleBook::RuleBook(ConfigChangeListener& configChangeListener, SyncModule& syncM
 
 RuleBook::~RuleBook() {}
 
-void RuleBook::init(const Blackboard* globalBlackboard)
+void RuleBook::init(std::shared_ptr<const Blackboard> globalBlackboard)
 {
     _globalBlackboard = globalBlackboard;
     _ps->setGlobalBlackboard(globalBlackboard);
@@ -181,9 +181,8 @@ PlanChange RuleBook::dynamicAllocationRule(RunningPlan& r)
             r.setAllocationNeeded(true);
         }
 
-        Logging::logInfo(LOGNAME) << "B4 dynChange: Util is " << curUtil << " | "
-                                  << " suggested is " << possibleUtil << " | "
-                                  << " threshold " << p->getUtilityThreshold() << "\n"
+        Logging::logInfo(LOGNAME) << "B4 dynChange: Util is " << curUtil << " | " << " suggested is " << possibleUtil << " | " << " threshold "
+                                  << p->getUtilityThreshold() << "\n"
                                   << "DynAlloc in " << p->getName();
 
         return PlanChange::InternalChange;
@@ -424,7 +423,7 @@ PlanChange RuleBook::transitionRule(RunningPlan& r)
             continue;
         }
 
-        if (t->getTransitionCondition()->evaluate(&r, _globalBlackboard, t->getKeyMapping())) {
+        if (t->getTransitionCondition()->evaluate(&r, _globalBlackboard.get(), t->getKeyMapping())) {
             nextState = t->getOutState();
             break;
         }
@@ -464,7 +463,7 @@ PlanChange RuleBook::synchTransitionRule(RunningPlan& rp)
             continue;
         }
         if (_syncModule.isTransitionSuccessfullySynchronised(t)) {
-            if (t->getTransitionCondition()->evaluate(&rp, _globalBlackboard, t->getKeyMapping())) {
+            if (t->getTransitionCondition()->evaluate(&rp, _globalBlackboard.get(), t->getKeyMapping())) {
                 // we follow the transition, because it holds and is synchronised
                 nextState = t->getOutState();
                 // TODO: Find solution for constraints with new transition conditions
@@ -476,7 +475,7 @@ PlanChange RuleBook::synchTransitionRule(RunningPlan& rp)
             }
         } else {
             // adds a new synchronisation process or updates existing
-            _syncModule.setSynchronisation(t, t->getTransitionCondition()->evaluate(&rp, _globalBlackboard, t->getKeyMapping()));
+            _syncModule.setSynchronisation(t, t->getTransitionCondition()->evaluate(&rp, _globalBlackboard.get(), t->getKeyMapping()));
         }
     }
     if (nextState == nullptr) {

--- a/alica_engine/src/engine/RunnableObject.cpp
+++ b/alica_engine/src/engine/RunnableObject.cpp
@@ -3,6 +3,7 @@
 #include "engine/BasicPlan.h"
 #include "engine/IAlicaCommunication.h"
 #include "engine/RunningPlan.h"
+#include "engine/blackboard/Blackboard.h"
 #include "engine/blackboard/BlackboardUtil.h"
 #include "engine/logging/Logging.h"
 #include "engine/model/ConfAbstractPlanWrapper.h"
@@ -13,7 +14,7 @@
 
 namespace alica
 {
-RunnableObject::RunnableObject(Blackboard& globalBlackboard, const IAlicaTraceFactory* tf, const std::string& name)
+RunnableObject::RunnableObject(std::shared_ptr<Blackboard> globalBlackboard, const IAlicaTraceFactory* tf, const std::string& name)
         : _name(name)
         , _msInterval(AlicaTime::milliseconds(DEFAULT_MS_INTERVAL))
         , _blackboardBlueprint(nullptr)
@@ -83,13 +84,7 @@ void RunnableObject::stopRunCalls()
 void RunnableObject::setupBlackboard()
 {
     if (!_runningplanContext->getParent() || !_runningplanContext->getParent()->getBasicPlan()) {
-        if (!_blackboard) {
-            if (_blackboardBlueprint) {
-                _blackboard = std::make_shared<Blackboard>(_blackboardBlueprint); // Potentially heavy operation. TBD optimize
-            } else {
-                _blackboard = std::make_shared<Blackboard>();
-            }
-        }
+        _blackboard = _blackboardBlueprint ? std::make_shared<Blackboard>(_blackboardBlueprint) : _globalBlackboard;
     } else if (!getInheritBlackboard()) {
         auto parentPlan = _runningplanContext->getParent();
         auto keyMapping = _runningplanContext->getKeyMapping();

--- a/alica_engine/src/engine/RunningPlan.cpp
+++ b/alica_engine/src/engine/RunningPlan.cpp
@@ -50,7 +50,7 @@ void RunningPlan::setAssignmentProtectionTime(AlicaTime t)
     s_assignmentProtectionTime = t;
 }
 
-RunningPlan::RunningPlan(ConfigChangeListener& configChangeListener, const AlicaClock& clock, const Blackboard& globalBlackboard,
+RunningPlan::RunningPlan(ConfigChangeListener& configChangeListener, const AlicaClock& clock, std::shared_ptr<const Blackboard> globalBlackboard,
         const RuntimePlanFactory& runTimePlanFactory, TeamObserver& teamObserver, TeamManager& teamManager, const PlanRepository& planRepository,
         VariableSyncModule& resultStore, const std::unordered_map<size_t, std::unique_ptr<ISolverBase>>& solvers)
         : _clock(clock)
@@ -75,8 +75,8 @@ RunningPlan::~RunningPlan()
     }
 }
 
-RunningPlan::RunningPlan(ConfigChangeListener& configChangeListener, const AlicaClock& clock, const Blackboard& globalBlackboard, TeamObserver& teamObserver,
-        TeamManager& teamManager, const PlanRepository& planRepository, VariableSyncModule& resultStore,
+RunningPlan::RunningPlan(ConfigChangeListener& configChangeListener, const AlicaClock& clock, std::shared_ptr<const Blackboard> globalBlackboard,
+        TeamObserver& teamObserver, TeamManager& teamManager, const PlanRepository& planRepository, VariableSyncModule& resultStore,
         const std::unordered_map<size_t, std::unique_ptr<ISolverBase>>& solvers, const RuntimePlanFactory& runTimePlanFactory,
         const RuntimeBehaviourFactory& runTimeBehaviourFactory, const AbstractPlan* abstractPlan, const ConfAbstractPlanWrapper* wrapper)
         : _clock(clock)
@@ -186,7 +186,7 @@ bool RunningPlan::evalPreCondition() const
         return true;
     }
     try {
-        return preCondition->evaluate(*this, &_globalBlackboard);
+        return preCondition->evaluate(*this, _globalBlackboard);
     } catch (const std::exception& e) {
         Logging::logError(LOGNAME) << "Exception in precondition: " << e.what();
         return false;
@@ -215,7 +215,7 @@ bool RunningPlan::evalRuntimeCondition() const
         return true;
     }
     try {
-        bool ret = runtimeCondition->evaluate(*this, &_globalBlackboard);
+        bool ret = runtimeCondition->evaluate(*this, _globalBlackboard);
         _status.runTimeConditionStatus = (ret ? EvalStatus::True : EvalStatus::False);
         return ret;
     } catch (const std::exception& e) {

--- a/alica_engine/src/engine/RuntimeBehaviourFactory.cpp
+++ b/alica_engine/src/engine/RuntimeBehaviourFactory.cpp
@@ -9,7 +9,7 @@
 namespace alica
 {
 
-RuntimeBehaviourFactory::RuntimeBehaviourFactory(Blackboard& globalBlackboard, TeamManager& teamManager, PlanBase& planBase,
+RuntimeBehaviourFactory::RuntimeBehaviourFactory(std::shared_ptr<Blackboard> globalBlackboard, TeamManager& teamManager, PlanBase& planBase,
         const IAlicaCommunication& communication, const IAlicaTraceFactory* traceFactory, const IAlicaTimerFactory& timerFactory)
         : _globalBlackboard(globalBlackboard)
         , _teamManager(teamManager)

--- a/alica_engine/src/engine/RuntimePlanFactory.cpp
+++ b/alica_engine/src/engine/RuntimePlanFactory.cpp
@@ -11,8 +11,8 @@
 namespace alica
 {
 
-RuntimePlanFactory::RuntimePlanFactory(
-        Blackboard& globalBlackboard, const IAlicaTraceFactory* traceFactory, const TeamManager& teamManager, const IAlicaTimerFactory& timerFactory)
+RuntimePlanFactory::RuntimePlanFactory(std::shared_ptr<Blackboard> globalBlackboard, const IAlicaTraceFactory* traceFactory, const TeamManager& teamManager,
+        const IAlicaTimerFactory& timerFactory)
         : _traceFactory(traceFactory)
         , _teamManager(teamManager)
         , _timerFactory(timerFactory)

--- a/alica_engine/src/engine/model/Condition.cpp
+++ b/alica_engine/src/engine/model/Condition.cpp
@@ -29,7 +29,7 @@ void Condition::setConditionString(const std::string& conditionString)
     _conditionString = conditionString;
 }
 
-bool Condition::evaluate(const RunningPlan& rp, const Blackboard* globalBlackboard) const
+bool Condition::evaluate(const RunningPlan& rp, std::shared_ptr<const Blackboard> globalBlackboard) const
 {
     if (_basicCondition == nullptr) {
         Logging::logDebug("Condition") << "Condition: Missing implementation of condition: ID " << getId();
@@ -38,7 +38,7 @@ bool Condition::evaluate(const RunningPlan& rp, const Blackboard* globalBlackboa
         bool ret = false;
         try {
             // TODO: fix const cast below
-            ret = _basicCondition->evaluate(const_cast<RunningPlan&>(rp).getSharedPointer(), globalBlackboard);
+            ret = _basicCondition->evaluate(const_cast<RunningPlan&>(rp).getSharedPointer(), globalBlackboard.get());
         } catch (const std::exception& e) {
             Logging::logDebug("Condition") << "Condition: Exception during evaluation catched:\n" << e.what();
         }

--- a/alica_engine/src/engine/modelmanagement/factories/BlackboardBlueprintFactory.cpp
+++ b/alica_engine/src/engine/modelmanagement/factories/BlackboardBlueprintFactory.cpp
@@ -13,7 +13,8 @@ std::unique_ptr<BlackboardBlueprint> BlackboardBlueprintFactory::create(const YA
         auto key = getValue<std::string>(entry, Strings::key);
         auto type = getValue<std::string>(entry, Strings::stateType);
         auto access = getValue<std::string>(entry, Strings::access);
-        blueprint->addKey(key, type, access);
+        auto defaultValue = getValue<std::string>(entry, Strings::defaultValue, std::string{});
+        blueprint->addKey(key, type, access, defaultValue);
     }
     return blueprint;
 }

--- a/alica_engine/src/engine/planselector/PlanSelector.cpp
+++ b/alica_engine/src/engine/planselector/PlanSelector.cpp
@@ -165,8 +165,7 @@ RunningPlan* PlanSelector::createRunningPlan(RunningPlan* planningParent, const 
         const EntryPoint* ep = rp->getAssignment().getEntryPointOfAgent(localAgentID);
 
         if (ep == nullptr) {
-            Logging::logDebug(LOGNAME) << "The agent "
-                                       << "(Id: " << localAgentID << ") is not assigned to enter the plan " << rp->getActivePlan()->getName()
+            Logging::logDebug(LOGNAME) << "The agent " << "(Id: " << localAgentID << ") is not assigned to enter the plan " << rp->getActivePlan()->getName()
                                        << " and will IDLE!";
 
             rp->useState(nullptr);
@@ -231,9 +230,9 @@ bool PlanSelector::getPlansForStateInternal(
     return true;
 }
 
-void PlanSelector::setGlobalBlackboard(const Blackboard* globalBlackboard)
+void PlanSelector::setGlobalBlackboard(std::shared_ptr<const Blackboard> globalBlackboard)
 {
-    _globalBlackboard = globalBlackboard;
+    _globalBlackboard = globalBlackboard.get();
 }
 
 } /* namespace alica */

--- a/alica_engine/src/engine/planselector/PlanSelector.cpp
+++ b/alica_engine/src/engine/planselector/PlanSelector.cpp
@@ -165,7 +165,8 @@ RunningPlan* PlanSelector::createRunningPlan(RunningPlan* planningParent, const 
         const EntryPoint* ep = rp->getAssignment().getEntryPointOfAgent(localAgentID);
 
         if (ep == nullptr) {
-            Logging::logDebug(LOGNAME) << "The agent " << "(Id: " << localAgentID << ") is not assigned to enter the plan " << rp->getActivePlan()->getName()
+            Logging::logDebug(LOGNAME) << "The agent "
+                                       << "(Id: " << localAgentID << ") is not assigned to enter the plan " << rp->getActivePlan()->getName()
                                        << " and will IDLE!";
 
             rp->useState(nullptr);

--- a/alica_tests/etc/behaviours/AddToValueBeh.beh
+++ b/alica_tests/etc/behaviours/AddToValueBeh.beh
@@ -3,6 +3,7 @@
     {
       "access": "output",
       "comment": "",
+      "defaultValue": null,
       "id": 466746386440200495,
       "key": "result",
       "type": "int64"
@@ -10,6 +11,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 472712871981904208,
       "key": "valueBase",
       "type": "int64"
@@ -17,6 +19,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 1801626755158684009,
       "key": "valueAddition",
       "type": "int64"

--- a/alica_tests/etc/behaviours/PlaceholderBehImpl.beh
+++ b/alica_tests/etc/behaviours/PlaceholderBehImpl.beh
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 438575867201420125,
       "key": "beh_key",
       "type": "int64"

--- a/alica_tests/etc/behaviours/PlaceholderBehKeyTypeNotMatchingImpl.beh
+++ b/alica_tests/etc/behaviours/PlaceholderBehKeyTypeNotMatchingImpl.beh
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 4452024279743045210,
       "key": "beh_key",
       "type": "std::string"

--- a/alica_tests/etc/behaviours/TestParameterPassingBehaviour.beh
+++ b/alica_tests/etc/behaviours/TestParameterPassingBehaviour.beh
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "This is a blackboard entry for testing",
+      "defaultValue": null,
       "id": 831672371947300202,
       "key": "behaviorInputKey",
       "type": "int64"
@@ -10,6 +11,7 @@
     {
       "access": "output",
       "comment": "This is a blackboard entry for testing",
+      "defaultValue": null,
       "id": 4355442070811434152,
       "key": "behaviorOutputKey",
       "type": "int64"
@@ -17,6 +19,7 @@
     {
       "access": "protected",
       "comment": "This is a blackboard entry for testing",
+      "defaultValue": null,
       "id": 4595223845781635836,
       "key": "behaviorKey",
       "type": "int64"

--- a/alica_tests/etc/behaviours/ValueMappingTestBeh.beh
+++ b/alica_tests/etc/behaviours/ValueMappingTestBeh.beh
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 295424301669504851,
       "key": "mappedIntValue",
       "type": "int64"
@@ -10,6 +11,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 1084164460275214238,
       "key": "mappedUintValue",
       "type": "uint64"
@@ -17,6 +19,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 2731459979076223059,
       "key": "mappedDoubleValue",
       "type": "double"
@@ -24,6 +27,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 2748136259550945350,
       "key": "mappedBoolValue",
       "type": "bool"
@@ -31,6 +35,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 2876478988214320958,
       "key": "mappedStringValue",
       "type": "std::string"

--- a/alica_tests/etc/conditions/ConditionRepository.cnd
+++ b/alica_tests/etc/conditions/ConditionRepository.cnd
@@ -46,6 +46,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 2632001281501051324,
           "key": "left",
           "type": "bool"
@@ -53,6 +54,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 4023745187844894171,
           "key": "right",
           "type": "bool"
@@ -85,6 +87,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 384076574199377370,
           "key": "right",
           "type": "uint64"
@@ -92,6 +95,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 1982942297730573553,
           "key": "left",
           "type": "uint64"
@@ -108,6 +112,7 @@
         {
           "access": "input",
           "comment": "If set to true the transition will evaluate to true",
+          "defaultValue": null,
           "id": 2436156389323048245,
           "key": "trigger",
           "type": "std::any"
@@ -132,6 +137,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 2966214154645332430,
           "key": "childStatus",
           "type": "std::any"
@@ -148,6 +154,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 3439523896613891265,
           "key": "expected",
           "type": "int64"
@@ -164,6 +171,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 2553683918549651059,
           "key": "right",
           "type": "int64"
@@ -171,6 +179,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 3834485219782018596,
           "key": "left",
           "type": "int64"
@@ -219,6 +228,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 3152208062592581092,
           "key": "left",
           "type": "std::string"
@@ -226,6 +236,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 3312826821967663639,
           "key": "right",
           "type": "std::string"
@@ -258,6 +269,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 2892375842724022590,
           "key": "right",
           "type": "double"
@@ -265,6 +277,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 3156302528056517151,
           "key": "left",
           "type": "double"
@@ -297,6 +310,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 723141806662039321,
           "key": "right",
           "type": "double"
@@ -304,6 +318,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 2191492142132193552,
           "key": "left",
           "type": "double"
@@ -336,6 +351,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 1067986686726517015,
           "key": "mappedStringValue",
           "type": "std::string"
@@ -343,6 +359,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 1072536082461203314,
           "key": "mappedIntValue",
           "type": "int64"
@@ -350,6 +367,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 1923116393503068456,
           "key": "mappedBoolValue",
           "type": "bool"
@@ -357,6 +375,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 2058698019148031741,
           "key": "mappedUintValue",
           "type": "uint64"
@@ -364,6 +383,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 2476010310420018929,
           "key": "mappedDoubleValue",
           "type": "double"
@@ -380,6 +400,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 4032224399589857774,
           "key": "numberOfCalls",
           "type": "int64"
@@ -412,6 +433,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 381679899215291123,
           "key": "right",
           "type": "int64"
@@ -419,6 +441,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 2135783783816304417,
           "key": "left",
           "type": "int64"
@@ -443,6 +466,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 2902028793069019089,
           "key": "numberOfCalls",
           "type": "int64"
@@ -459,6 +483,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 3389293809385623999,
           "key": "expected",
           "type": "int64"
@@ -483,6 +508,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 1590410157820316490,
           "key": "left",
           "type": "uint64"
@@ -490,6 +516,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 4482746889389936092,
           "key": "right",
           "type": "uint64"
@@ -506,6 +533,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 2610737155421779161,
           "key": "childName",
           "type": "std::string"
@@ -530,6 +558,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 924760096646037639,
           "key": "result",
           "type": "bool"
@@ -554,6 +583,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 2423941618748335792,
           "key": "expected",
           "type": "int64"
@@ -570,6 +600,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 4313717753229417761,
           "key": "idx",
           "type": "int64"
@@ -602,6 +633,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 297103765735860664,
           "key": "right",
           "type": "std::string"
@@ -609,6 +641,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 423497022241155678,
           "key": "left",
           "type": "std::string"

--- a/alica_tests/etc/placeholders/BehPlaceholder.plh
+++ b/alica_tests/etc/placeholders/BehPlaceholder.plh
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 438575867201420768,
       "key": "beh_key",
       "type": "int64"

--- a/alica_tests/etc/placeholders/PlanPlaceholder.plh
+++ b/alica_tests/etc/placeholders/PlanPlaceholder.plh
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 1515319670549888806,
       "key": "plan_key",
       "type": "int64"

--- a/alica_tests/etc/plans/AddToValuePlan.pml
+++ b/alica_tests/etc/plans/AddToValuePlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 673530961515765443,
       "key": "valueBase",
       "type": "int64"
@@ -10,6 +11,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 2187064918328734759,
       "key": "valueAddition",
       "type": "int64"
@@ -17,6 +19,7 @@
     {
       "access": "output",
       "comment": "",
+      "defaultValue": null,
       "id": 3106466143130241111,
       "key": "result",
       "type": "int64"

--- a/alica_tests/etc/plans/BlackboardTestPlan.pml
+++ b/alica_tests/etc/plans/BlackboardTestPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1604125167842760918,
       "key": "ChooseBlackboardTestState2ValueMappingPlanTestState",
       "type": "bool"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 2499503172139630260,
       "key": "ChooseBlackboardTestState2ValueMappingBehaviourTestState",
       "type": "bool"
@@ -17,6 +19,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3790159344295070800,
       "key": "ChooseBlackboardTestState2ValueMappingConditionTestState",
       "type": "bool"
@@ -24,6 +27,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3928341634460937152,
       "key": "ChooseBlackboardTestState2PopulateBlackboardTestState",
       "type": "bool"

--- a/alica_tests/etc/plans/ExecOrderTestPlan.pml
+++ b/alica_tests/etc/plans/ExecOrderTestPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1592696283737954035,
       "key": "EntryState2PlanAState",
       "type": "bool"

--- a/alica_tests/etc/plans/HandleFailExplicit.pml
+++ b/alica_tests/etc/plans/HandleFailExplicit.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 4227261568323854459,
       "key": "aToBSwitch",
       "type": "int64"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 4460455267274597988,
       "key": "cToDSwitch",
       "type": "int64"

--- a/alica_tests/etc/plans/ParallelSuccessOnCondPlan.pml
+++ b/alica_tests/etc/plans/ParallelSuccessOnCondPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3797646244448202675,
       "key": "WaitForTriggerState2ParallelExecState",
       "type": "bool"

--- a/alica_tests/etc/plans/PlaceholderPlanImpl.pml
+++ b/alica_tests/etc/plans/PlaceholderPlanImpl.pml
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 1515319670549888957,
       "key": "plan_key",
       "type": "int64"

--- a/alica_tests/etc/plans/PlaceholderPlanKeyTypeNotMatchingImpl.pml
+++ b/alica_tests/etc/plans/PlaceholderPlanKeyTypeNotMatchingImpl.pml
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 3732747204235607490,
       "key": "plan_key",
       "type": "std::string"

--- a/alica_tests/etc/plans/PopulateBlackboardTestPlan.pml
+++ b/alica_tests/etc/plans/PopulateBlackboardTestPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 14128325898465596,
       "key": "not_in_data_key",
       "type": "std::string"
@@ -10,6 +11,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 37366997480187649,
       "key": "data",
       "type": "std::string"
@@ -17,6 +19,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1830052697140273434,
       "key": "double_key",
       "type": "double"
@@ -24,6 +27,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3065125271564665902,
       "key": "bool_key",
       "type": "bool"
@@ -31,6 +35,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3141833006463785136,
       "key": "OtherChecksState2PopulatedState",
       "type": "bool"
@@ -38,6 +43,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3179113368759389835,
       "key": "int64_key",
       "type": "int64"
@@ -45,6 +51,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3542073533896409826,
       "key": "string_key",
       "type": "std::string"
@@ -52,6 +59,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 4501786985394765844,
       "key": "uint64_key",
       "type": "uint64"

--- a/alica_tests/etc/plans/SameBehInParallelTestPlan.pml
+++ b/alica_tests/etc/plans/SameBehInParallelTestPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 549074179013053940,
       "key": "resultOne",
       "type": "int64"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3537510304698959535,
       "key": "resultTwo",
       "type": "int64"
@@ -17,6 +19,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 4053503531230885495,
       "key": "EntryState2FirstCheckState",
       "type": "bool"

--- a/alica_tests/etc/plans/SameInParallelTestPlan.pml
+++ b/alica_tests/etc/plans/SameInParallelTestPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1911668482379994475,
       "key": "ChooseTestState2SamePlanInParallelTestState",
       "type": "bool"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 2582201225876137224,
       "key": "ChooseTestState2SamePlanBehInParallelTestState",
       "type": "bool"
@@ -17,6 +19,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3573177713798947170,
       "key": "ChooseTestState2SameBehInParallelTestState",
       "type": "bool"

--- a/alica_tests/etc/plans/SamePlanBehInParallelTestPlan.pml
+++ b/alica_tests/etc/plans/SamePlanBehInParallelTestPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 762584330532259947,
       "key": "planResultTwo",
       "type": "int64"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 772996229802355990,
       "key": "behResultOne",
       "type": "int64"
@@ -17,6 +19,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 845172727750198208,
       "key": "behResultTwo",
       "type": "int64"
@@ -24,6 +27,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 4501937621687609404,
       "key": "planResultOne",
       "type": "int64"
@@ -31,6 +35,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 4576317543403705127,
       "key": "EntryState2FirstCheckState",
       "type": "bool"

--- a/alica_tests/etc/plans/SamePlanInParallelTestPlan.pml
+++ b/alica_tests/etc/plans/SamePlanInParallelTestPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 462984650222620929,
       "key": "resultOne",
       "type": "int64"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 2682650488249660408,
       "key": "resultTwo",
       "type": "int64"
@@ -17,6 +19,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3145297303645115724,
       "key": "EntryState2FirstCheckState",
       "type": "bool"
@@ -24,6 +27,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3615653659634051508,
       "key": "resultThree",
       "type": "int64"

--- a/alica_tests/etc/plans/SchedulingPlanTestPlan.pml
+++ b/alica_tests/etc/plans/SchedulingPlanTestPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3771375519284262837,
       "key": "EntryState2CheckState",
       "type": "bool"

--- a/alica_tests/etc/plans/SchedulingTestPlan.pml
+++ b/alica_tests/etc/plans/SchedulingTestPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 525979646733597400,
       "key": "ChooseTestState2TransitionAfterInitTestState",
       "type": "bool"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1344107288428655911,
       "key": "ChooseTestState2RepeatedRunCallsTestState",
       "type": "bool"
@@ -17,6 +19,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1375412086750652826,
       "key": "ChooseTestState2ExecOrderTestState",
       "type": "bool"
@@ -24,6 +27,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3103901468860392175,
       "key": "ChooseTestState2SchedulingPlanTestState",
       "type": "bool"

--- a/alica_tests/etc/plans/SimpleTestPlan.pml
+++ b/alica_tests/etc/plans/SimpleTestPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3196801973742034307,
       "key": "targetChildStatus",
       "type": "std::any"

--- a/alica_tests/etc/plans/StandardLibraryCompareConditionsPlan.pml
+++ b/alica_tests/etc/plans/StandardLibraryCompareConditionsPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 768854120689557866,
       "key": "CompareCondition2CompareLessThanString",
       "type": "bool"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 773855036706857873,
       "key": "valueBool",
       "type": "bool"
@@ -17,6 +19,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1323131406628204752,
       "key": "valueUint64",
       "type": "uint64"
@@ -24,6 +27,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1455619520226910856,
       "key": "valueInt64",
       "type": "int64"
@@ -31,6 +35,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1594166873455497029,
       "key": "valueDouble",
       "type": "double"
@@ -38,6 +43,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3758731991465578044,
       "key": "CompareCondition2CompareEqualString",
       "type": "bool"
@@ -45,6 +51,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 4339086657243043033,
       "key": "valueString",
       "type": "std::string"

--- a/alica_tests/etc/plans/SuccessOnCondPlan.pml
+++ b/alica_tests/etc/plans/SuccessOnCondPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1223260418939648240,
       "key": "WaitForCondState2CondSuccessState",
       "type": "bool"

--- a/alica_tests/etc/plans/SuccessOnCondWrapperAPlan.pml
+++ b/alica_tests/etc/plans/SuccessOnCondWrapperAPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1051145281711502661,
       "key": "SuccessOnCondState2WrapperASuccessState",
       "type": "bool"

--- a/alica_tests/etc/plans/SuccessOnCondWrapperBPlan.pml
+++ b/alica_tests/etc/plans/SuccessOnCondWrapperBPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 429816023887602514,
       "key": "SuccessOnCondState2WrapperBSuccessState",
       "type": "bool"

--- a/alica_tests/etc/plans/TestGlobalBlackboardMaster.pml
+++ b/alica_tests/etc/plans/TestGlobalBlackboardMaster.pml
@@ -1,0 +1,74 @@
+{
+  "blackboard": [
+    {
+      "access": "protected",
+      "comment": "",
+      "id": 1202182562814773905,
+      "key": "masterKey",
+      "type": "int64"
+    }
+  ],
+  "comment": "",
+  "entryPoints": [
+    {
+      "comment": "",
+      "id": 3343320852743350914,
+      "isDynamic": false,
+      "maxCardinality": 2147483647,
+      "minCardinality": 0,
+      "name": "",
+      "plan": 450195508701585436,
+      "positionWeb": {
+        "x": 274,
+        "y": 255.30540466308594
+      },
+      "state": 2931682442813202891,
+      "successRequired": false,
+      "task": "taskrepository.tsk#1225112227903"
+    }
+  ],
+  "frequency": 30,
+  "id": 450195508701585436,
+  "implementationName": "",
+  "inheritBlackboard": true,
+  "isInterface": false,
+  "libraryName": "alica-tests",
+  "masterPlan": true,
+  "name": "TestGlobalBlackboardMaster",
+  "preCondition": null,
+  "runtimeCondition": null,
+  "states": [
+    {
+      "comment": "",
+      "confAbstractPlanWrappers": [
+        {
+          "abstractPlan": "TestInheritBlackboard.pml#1692837668719979400",
+          "comment": "",
+          "configuration": null,
+          "id": 948772846071364571,
+          "keyMapping": {
+            "input": [],
+            "output": []
+          },
+          "name": ""
+        }
+      ],
+      "entryPoint": 3343320852743350914,
+      "id": 2931682442813202891,
+      "inTransitions": [],
+      "name": "InheritBlackboardRunSubPlan",
+      "outTransitions": [],
+      "parentPlan": 450195508701585436,
+      "positionWeb": {
+        "x": 483,
+        "y": 242.30540466308594
+      },
+      "type": "State",
+      "variableBindings": []
+    }
+  ],
+  "synchronisations": [],
+  "transitions": [],
+  "utilityThreshold": 0.0,
+  "variables": []
+}

--- a/alica_tests/etc/plans/TestGlobalBlackboardMaster.pml
+++ b/alica_tests/etc/plans/TestGlobalBlackboardMaster.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": "123",
       "id": 1202182562814773905,
       "key": "masterKey",
       "type": "int64"

--- a/alica_tests/etc/plans/TestInheritBlackboardMaster.pml
+++ b/alica_tests/etc/plans/TestInheritBlackboardMaster.pml
@@ -27,7 +27,7 @@
       "task": "taskrepository.tsk#1225112227903"
     }
   ],
-  "frequency": 0,
+  "frequency": 30,
   "id": 1179066429431332056,
   "implementationName": "",
   "inheritBlackboard": false,

--- a/alica_tests/etc/plans/TestInheritBlackboardMaster.pml
+++ b/alica_tests/etc/plans/TestInheritBlackboardMaster.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "This is a blackboard entry for testing",
+      "defaultValue": null,
       "id": 1944554894288661764,
       "key": "masterKey",
       "type": "int64"

--- a/alica_tests/etc/plans/TestMasterPlan.pml
+++ b/alica_tests/etc/plans/TestMasterPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 295638103823734752,
       "key": "ChooseTestState2AdjacentSuccessTestState",
       "type": "bool"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 330153981060768900,
       "key": "ChooseTestState2BehSuccessTestState",
       "type": "bool"
@@ -17,6 +19,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 754979557833243222,
       "key": "ChooseTestState2MultiPlanInstanceSuccessTestState",
       "type": "bool"
@@ -24,6 +27,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 805305087691207519,
       "key": "ChooseTestState2SchedulingTestState",
       "type": "bool"
@@ -31,6 +35,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1487451634780526767,
       "key": "ChooseTestState2PlanSuccessTestState",
       "type": "bool"
@@ -38,6 +43,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 2172263233610170275,
       "key": "ChooseTestState2SamePlanInParallelTestState",
       "type": "bool"
@@ -45,6 +51,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 2253124628702855079,
       "key": "ChooseTestState2PlaceholderTestState",
       "type": "bool"
@@ -52,6 +59,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 2321498751406550734,
       "key": "ChooseTestState2BlackboardTestState",
       "type": "bool"
@@ -59,6 +67,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3151624094246832948,
       "key": "ChooseTestState2StandardLibraryCompareConditionsState",
       "type": "bool"
@@ -66,6 +75,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3421733107371844672,
       "key": "ChooseTestState2IsChildSuccessTestState",
       "type": "bool"
@@ -73,6 +83,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 4056440268292823384,
       "key": "ChooseTestState2SameInParallelTestState",
       "type": "bool"

--- a/alica_tests/etc/plans/TestParameterPassing.pml
+++ b/alica_tests/etc/plans/TestParameterPassing.pml
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "This is a blackboard entry for testing",
+      "defaultValue": null,
       "id": 785752561217999359,
       "key": "planInputFromMaster",
       "type": "int64"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1610853554686361041,
       "key": "targetChildStatus",
       "type": "std::any"
@@ -17,6 +19,7 @@
     {
       "access": "protected",
       "comment": "This is a blackboard entry for testing",
+      "defaultValue": null,
       "id": 1779079550934584473,
       "key": "planSecondOutputKey",
       "type": "int64"
@@ -24,6 +27,7 @@
     {
       "access": "protected",
       "comment": "This is a blackboard entry for testing",
+      "defaultValue": null,
       "id": 1907383426694952412,
       "key": "planKey",
       "type": "int64"
@@ -31,6 +35,7 @@
     {
       "access": "protected",
       "comment": "This is a blackboard entry for testing",
+      "defaultValue": null,
       "id": 3008593874445613740,
       "key": "planOutputKey",
       "type": "int64"
@@ -38,6 +43,7 @@
     {
       "access": "protected",
       "comment": "This is a blackboard entry for testing",
+      "defaultValue": null,
       "id": 4362502621284224779,
       "key": "planInputKey",
       "type": "int64"

--- a/alica_tests/etc/plans/TestParameterPassingMaster.pml
+++ b/alica_tests/etc/plans/TestParameterPassingMaster.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "This is a blackboard entry for testing",
+      "defaultValue": null,
       "id": 3046890668195475143,
       "key": "masterKey",
       "type": "int64"

--- a/alica_tests/etc/plans/TestRepeatedRunsPlan.pml
+++ b/alica_tests/etc/plans/TestRepeatedRunsPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1487312086401574568,
       "key": "EntryState2CheckState",
       "type": "bool"

--- a/alica_tests/etc/plans/ValueMappingPlanTestPlan.pml
+++ b/alica_tests/etc/plans/ValueMappingPlanTestPlan.pml
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 54989083355939699,
       "key": "mappedBoolValue",
       "type": "bool"
@@ -10,6 +11,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 1234313196608957375,
       "key": "mappedDoubleValue",
       "type": "double"
@@ -17,6 +19,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 1535353035896902577,
       "key": "mappedIntValue",
       "type": "int64"
@@ -24,6 +27,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 2933912270549461002,
       "key": "mappedUintValue",
       "type": "uint64"
@@ -31,6 +35,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 4434332895838233306,
       "key": "mappedStringValue",
       "type": "std::string"

--- a/alica_tests/include/alica_tests/plans/TestGlobalBlackboardMaster.h
+++ b/alica_tests/include/alica_tests/plans/TestGlobalBlackboardMaster.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <alica_tests/util/AlicaTestsPlan.h>
+#include <boost/dll/alias.hpp>
+#include <engine/BasicPlan.h>
+#include <engine/BasicUtilityFunction.h>
+#include <engine/DefaultUtilityFunction.h>
+#include <engine/UtilityFunction.h>
+
+namespace alica
+{
+class TestGlobalBlackboardMaster : public AlicaTestsPlan<TestGlobalBlackboardMaster>
+{
+public:
+    TestGlobalBlackboardMaster(PlanContext& context);
+
+protected:
+    virtual void run() override;
+    virtual void onInit() override;
+};
+
+BOOST_DLL_ALIAS(alica::TestGlobalBlackboardMaster::create, TestGlobalBlackboardMaster)
+BOOST_DLL_ALIAS(alica::BasicUtilityFunction::create, TestGlobalBlackboardMasterUtilityFunction)
+
+} /* namespace alica */

--- a/alica_tests/include/alica_tests/plans/TestInheritBlackboardMaster.h
+++ b/alica_tests/include/alica_tests/plans/TestInheritBlackboardMaster.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <alica_tests/util/AlicaTestsPlan.h>
 #include <boost/dll/alias.hpp>
 #include <engine/BasicPlan.h>
 #include <engine/BasicUtilityFunction.h>
@@ -8,13 +9,17 @@
 
 namespace alica
 {
-class TestInheritBlackboardMaster : public BasicPlan
+class TestInheritBlackboardMaster : public AlicaTestsPlan<TestInheritBlackboardMaster>
 {
 public:
     TestInheritBlackboardMaster(PlanContext& context);
+
+protected:
+    virtual void run() override;
+    virtual void onInit() override;
 };
 
-BOOST_DLL_ALIAS(alica::BasicPlan::create, TestInheritBlackboardMaster)
+BOOST_DLL_ALIAS(alica::TestInheritBlackboardMaster::create, TestInheritBlackboardMaster)
 BOOST_DLL_ALIAS(alica::BasicUtilityFunction::create, TestInheritBlackboardMasterUtilityFunction)
 
 } /* namespace alica */

--- a/alica_tests/include/test_alica.h
+++ b/alica_tests/include/test_alica.h
@@ -350,7 +350,7 @@ public:
         path = THIS_PACKAGE_DIR;
 #endif
         std::cerr << "create with " << path + "/config/" + getPlaceholderMappingFileName() << std::endl;
-        _tc = std::make_unique<TestContext>(agentName(), std::vector<std::string>{path + "/etc/"}, "Roleset", "TestMasterPlan", true, 1,
+        _tc = std::make_unique<TestContext>(agentName(), std::vector<std::string>{path + "/etc/"}, "Roleset", getMasterPlanName(), true, 1,
                 readPlaceholderMapping(path + "/config/" + getPlaceholderMappingFileName()));
         ASSERT_TRUE(_tc->isValid());
     }
@@ -366,7 +366,7 @@ public:
         _tc->init(std::move(creators));
         _tc->startEngine();
 
-        STEP_UNTIL_ASSERT_TRUE(_tc, _tc->getActivePlan("TestMasterPlan")) << _tc->getLastFailure();
+        STEP_UNTIL_ASSERT_TRUE(_tc, _tc->getActivePlan(getMasterPlanName())) << _tc->getLastFailure();
     }
 
     virtual void TearDown() override {}
@@ -390,6 +390,8 @@ protected:
         return maybeMapping;
     }
 
+    virtual const char* getMasterPlanName() const { return "TestMasterPlan"; }
+
     std::unique_ptr<TestContext> _tc;
 };
 
@@ -405,6 +407,9 @@ public:
     }
 
     virtual void TearDown() override { Base::TearDown(); }
+
+protected:
+    virtual const char* getMasterPlanName() const override { return "TestMasterPlan"; }
 };
 
 } // namespace alica::test

--- a/alica_tests/src/behaviours/TestInheritBlackboardBehaviour.cpp
+++ b/alica_tests/src/behaviours/TestInheritBlackboardBehaviour.cpp
@@ -1,6 +1,6 @@
-#include "alica_tests/TestWorldModel.h"
 #include <alica_tests/behaviours/TestInheritBlackboardBehaviour.h>
 
+#include <cstdint>
 #include <memory>
 
 namespace alica
@@ -14,15 +14,14 @@ TestInheritBlackboardBehaviour::~TestInheritBlackboardBehaviour() {}
 void TestInheritBlackboardBehaviour::run() {}
 void TestInheritBlackboardBehaviour::initialiseParameters()
 {
-    auto wm = LockedBlackboardRW(*getGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
-    LockedBlackboardRW bb(*(getBlackboard()));
-    bb.set<int64_t>("masterKey", 3);
-    wm->passedParameters["masterKeyInBehavior"] = bb.get<int64_t>("masterKey");
-    if (bb.hasValue("behaviorKey")) {
-        wm->passedParameters["hasBehaviorKey"] = 3;
-    } else {
-        wm->passedParameters["hasBehaviorKey"] = 4;
+    int64_t masterKeyInBehavior = 0;
+    {
+        LockedBlackboardRW bb(*getBlackboard());
+        masterKeyInBehavior = bb.get<int64_t>("masterKey");
+        bb.set<int64_t>("behaviourKey", 323);
     }
+    LockedBlackboardRW gb(*getGlobalBlackboard());
+    gb.set("masterKeyInBehaviour", masterKeyInBehavior);
 }
 std::unique_ptr<TestInheritBlackboardBehaviour> TestInheritBlackboardBehaviour::create(alica::BehaviourContext& context)
 {

--- a/alica_tests/src/plans/TestGlobalBlackboardMaster.cpp
+++ b/alica_tests/src/plans/TestGlobalBlackboardMaster.cpp
@@ -7,11 +7,7 @@ TestGlobalBlackboardMaster::TestGlobalBlackboardMaster(PlanContext& context)
 {
 }
 
-void TestGlobalBlackboardMaster::onInit()
-{
-    LockedBlackboardRW bb(*getBlackboard());
-    bb.set<int64_t>("masterKey", 123);
-}
+void TestGlobalBlackboardMaster::onInit() {}
 
 void TestGlobalBlackboardMaster::run()
 {

--- a/alica_tests/src/plans/TestGlobalBlackboardMaster.cpp
+++ b/alica_tests/src/plans/TestGlobalBlackboardMaster.cpp
@@ -1,0 +1,31 @@
+#include <alica_tests/plans/TestGlobalBlackboardMaster.h>
+
+namespace alica
+{
+TestGlobalBlackboardMaster::TestGlobalBlackboardMaster(PlanContext& context)
+        : AlicaTestsPlan(context)
+{
+}
+
+void TestGlobalBlackboardMaster::onInit()
+{
+    LockedBlackboardRW bb(*getBlackboard());
+    bb.set<int64_t>("masterKey", 123);
+}
+
+void TestGlobalBlackboardMaster::run()
+{
+    std::optional<int64_t> behaviourKeyInMaster;
+    {
+        LockedBlackboardRW bb(*getBlackboard());
+        if (bb.hasValue("behaviourKey")) {
+            behaviourKeyInMaster = bb.get<int64_t>("behaviourKey");
+        }
+    }
+    if (behaviourKeyInMaster.has_value()) {
+        LockedBlackboardRW gb(*getGlobalBlackboard());
+        gb.set("behaviourKeyInMaster", behaviourKeyInMaster.value());
+    }
+}
+
+} // namespace alica

--- a/alica_tests/src/plans/TestInheritBlackboardMaster.cpp
+++ b/alica_tests/src/plans/TestInheritBlackboardMaster.cpp
@@ -3,7 +3,29 @@
 namespace alica
 {
 TestInheritBlackboardMaster::TestInheritBlackboardMaster(PlanContext& context)
-        : BasicPlan(context)
+        : AlicaTestsPlan(context)
 {
 }
+
+void TestInheritBlackboardMaster::onInit()
+{
+    LockedBlackboardRW bb(*getBlackboard());
+    bb.set<int64_t>("masterKey", 123);
+}
+
+void TestInheritBlackboardMaster::run()
+{
+    std::optional<int64_t> behaviourKeyInMaster;
+    {
+        LockedBlackboardRW bb(*getBlackboard());
+        if (bb.hasValue("behaviourKey")) {
+            behaviourKeyInMaster = bb.get<int64_t>("behaviourKey");
+        }
+    }
+    if (behaviourKeyInMaster.has_value()) {
+        LockedBlackboardRW gb(*getGlobalBlackboard());
+        gb.set("behaviourKeyInMaster", behaviourKeyInMaster.value());
+    }
+}
+
 } // namespace alica

--- a/alica_tests/src/test/test_blackboard.cpp
+++ b/alica_tests/src/test/test_blackboard.cpp
@@ -170,7 +170,7 @@ TEST_F(TestBlackboard, testJsonTwoBehaviorKeyMapping)
     ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(200));
 
     std::shared_ptr<alicaTests::TestWorldModel> wm =
-            LockedBlackboardRW(ae->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
+            LockedBlackboardRW(ac->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
     EXPECT_EQ(wm->passedParameters["behaviorInputKey"], 5);       // Value set in first behavior call
     EXPECT_EQ(wm->passedParameters["behaviorSecondInputKey"], 7); // Value set in second behavior call
 }
@@ -181,7 +181,7 @@ TEST_F(TestBlackboard, testJsonPlanKeyMapping)
     ae->start();
     ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(200));
     std::shared_ptr<alicaTests::TestWorldModel> wm =
-            LockedBlackboardRW(ae->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
+            LockedBlackboardRW(ac->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
     EXPECT_EQ(wm->passedParameters["planInputFromMaster"], 8);
 }
 
@@ -191,7 +191,7 @@ TEST_F(TestBlackboard, testJsonBehaviorKeyMapping)
     ae->start();
     ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(200));
     std::shared_ptr<alicaTests::TestWorldModel> wm =
-            LockedBlackboardRW(ae->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
+            LockedBlackboardRW(ac->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
     EXPECT_EQ(wm->passedParameters["behaviorInputKey"], 5); // Value set in plan init -> read in behavior
     EXPECT_EQ(wm->passedParameters["planInputKey"], 6);     // Value set in behavior -> read in plan termination
 }
@@ -202,7 +202,7 @@ TEST_F(TestBlackboard, testJsonBlackboardPlan)
     ae->start();
     ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(100));
     std::shared_ptr<alicaTests::TestWorldModel> wm =
-            LockedBlackboardRW(ae->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
+            LockedBlackboardRW(ac->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
     EXPECT_EQ(wm->passedParameters["planKey"], 1);
 }
 
@@ -212,7 +212,7 @@ TEST_F(TestBlackboard, testJsonBlackboardBehavior)
     ae->start();
     ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(100));
     std::shared_ptr<alicaTests::TestWorldModel> wm =
-            LockedBlackboardRW(ae->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
+            LockedBlackboardRW(ac->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
     EXPECT_EQ(wm->passedParameters["behaviorKey"], 2);
 }
 

--- a/alica_tests/src/test/test_inherit_blackboard.cpp
+++ b/alica_tests/src/test/test_inherit_blackboard.cpp
@@ -1,39 +1,32 @@
 #include "alica_tests/TestWorldModel.h"
 #include "test_alica.h"
 #include <alica/test/Util.h>
+#include <chrono>
+#include <engine/blackboard/Blackboard.h>
+#include <gtest/gtest.h>
+#include <thread>
 
 namespace alica
 {
 namespace
 {
 
-class TestInheritBlackboard : public AlicaTestFixture
+class TestInheritBlackboard : public test::SingleAgentTestFixture
 {
 protected:
-    const char* getRoleSetName() const override { return "Roleset"; }
     const char* getMasterPlanName() const override { return "TestInheritBlackboardMaster"; }
-    bool stepEngine() const override { return false; }
 };
 
 TEST_F(TestInheritBlackboard, testInheritBlackboard)
 {
-    // Use inherited blackboards and check if keys are accessible
-    ae->start();
-    ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(100));
-    std::shared_ptr<alicaTests::TestWorldModel> wm =
-            LockedBlackboardRW(ac->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
-    EXPECT_EQ(wm->passedParameters["masterKeyInBehavior"], 3); // Read a key defined in the master plan inside the behavior
-    EXPECT_EQ(wm->passedParameters["hasBehaviorKey"], 4);      // Check that a key defined in the behavior is not available in the master plan
-}
-
-TEST_F(TestInheritBlackboard, testInheritBlackboardFlag)
-{
-    ae->start();
-    ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(100));
-    // Behaviour has inheritBlackboard set to false
-    EXPECT_TRUE(alica::test::Util::getBasicBehaviour(ae, 831400441334251600)->getInheritBlackboard());
-    // Plan has inheritBlackboard set to false
-    EXPECT_TRUE(alica::test::Util::getBasicPlan(ae, 1692837668719979400)->getInheritBlackboard());
+    // Use inherited blackboards and check if keys are accessible accross inheriting plans & behaviours
+    STEP_UNTIL(_tc, _tc->getActiveBehaviour("TestInheritBlackboardBehaviour"));
+    ASSERT_NE(_tc->getActiveBehaviour("TestInheritBlackboardBehaviour"), nullptr) << _tc->getLastFailure();
+    STEP_UNTIL(_tc, LockedBlackboardRO{*_tc->getGlobalBlackboardShared()}.hasValue("behaviourKeyInMaster"));
+    LockedBlackboardRO gb(*_tc->getGlobalBlackboardShared());
+    ASSERT_TRUE(gb.hasValue("behaviourKeyInMaster"));
+    ASSERT_EQ(gb.get<int64_t>("masterKeyInBehaviour"), 123);
+    ASSERT_EQ(gb.get<int64_t>("behaviourKeyInMaster"), 323);
 }
 
 } // namespace

--- a/alica_tests/src/test/test_inherit_blackboard.cpp
+++ b/alica_tests/src/test/test_inherit_blackboard.cpp
@@ -21,7 +21,7 @@ TEST_F(TestInheritBlackboard, testInheritBlackboard)
     ae->start();
     ae->getAlicaClock().sleep(alica::AlicaTime::milliseconds(100));
     std::shared_ptr<alicaTests::TestWorldModel> wm =
-            LockedBlackboardRW(ae->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
+            LockedBlackboardRW(ac->editGlobalBlackboard()).get<std::shared_ptr<alicaTests::TestWorldModel>>("worldmodel");
     EXPECT_EQ(wm->passedParameters["masterKeyInBehavior"], 3); // Read a key defined in the master plan inside the behavior
     EXPECT_EQ(wm->passedParameters["hasBehaviorKey"], 4);      // Check that a key defined in the behavior is not available in the master plan
 }

--- a/alica_tests/src/test/test_inherit_blackboard.cpp
+++ b/alica_tests/src/test/test_inherit_blackboard.cpp
@@ -29,5 +29,28 @@ TEST_F(TestInheritBlackboard, testInheritBlackboard)
     ASSERT_EQ(gb.get<int64_t>("behaviourKeyInMaster"), 323);
 }
 
+class TestGlobalBlackboard : public test::SingleAgentTestFixture
+{
+protected:
+    const char* getMasterPlanName() const override { return "TestGlobalBlackboardMaster"; }
+};
+
+TEST_F(TestGlobalBlackboard, testGlobalBlackboard)
+{
+    // Master plan's blackboard is marked as global (inherited) & sub-plans & behaviours inherit from it. Therefore all keys
+    // set in every plan & behaviour should be available in the global blackboard
+    STEP_UNTIL(_tc, _tc->getActiveBehaviour("TestInheritBlackboardBehaviour"));
+    ASSERT_NE(_tc->getActiveBehaviour("TestInheritBlackboardBehaviour"), nullptr) << _tc->getLastFailure();
+    STEP_UNTIL(_tc, LockedBlackboardRO{*_tc->getGlobalBlackboardShared()}.hasValue("behaviourKeyInMaster"));
+    LockedBlackboardRO gb(*_tc->getGlobalBlackboardShared());
+    ASSERT_TRUE(gb.hasValue("behaviourKeyInMaster"));
+    ASSERT_EQ(gb.get<int64_t>("masterKeyInBehaviour"), 123);
+    ASSERT_EQ(gb.get<int64_t>("behaviourKeyInMaster"), 323);
+    ASSERT_TRUE(gb.hasValue("masterKey"));
+    ASSERT_EQ(gb.get<int64_t>("masterKey"), 123);
+    ASSERT_TRUE(gb.hasValue("behaviourKey"));
+    ASSERT_EQ(gb.get<int64_t>("behaviourKey"), 323);
+}
+
 } // namespace
 } // namespace alica

--- a/supplementary/alica_ros1/alica_ros_turtlesim/etc/behaviours/WaitForMsg.beh
+++ b/supplementary/alica_ros1/alica_ros_turtlesim/etc/behaviours/WaitForMsg.beh
@@ -3,6 +3,7 @@
     {
       "access": "output",
       "comment": "The contents of the msg that was received on the topic",
+      "defaultValue": null,
       "id": 1670287826314001481,
       "key": "msg",
       "type": "std::string"
@@ -10,6 +11,7 @@
     {
       "access": "input",
       "comment": "The topic name on which to wait for the msg",
+      "defaultValue": null,
       "id": 3377017469681391113,
       "key": "topic",
       "type": "std::string"

--- a/supplementary/alica_ros1/alica_ros_turtlesim/etc/behaviours/WaitForTrigger.beh
+++ b/supplementary/alica_ros1/alica_ros_turtlesim/etc/behaviours/WaitForTrigger.beh
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "subscriber topic on which to listen for trigger msgs",
+      "defaultValue": null,
       "id": 2590992428289220704,
       "key": "topic",
       "type": "std::string"

--- a/supplementary/alica_ros1/supplementary_tests/src/test/test_alica_dynamicloadcreator.cpp
+++ b/supplementary/alica_ros1/supplementary_tests/src/test/test_alica_dynamicloadcreator.cpp
@@ -56,10 +56,10 @@ public:
         return path;
     }
 
-    Blackboard& getGlobalBlackboard() { return _globalBlackboard; }
+    std::shared_ptr<Blackboard> getGlobalBlackboard() { return std::make_shared<Blackboard>(); }
 
 private:
-    Blackboard _globalBlackboard;
+    std::shared_ptr<Blackboard> _globalBlackboard;
 };
 
 TEST_F(AlicaDynamicLoading, simple_behaviour_load)

--- a/supplementary/alica_turtlesim/etc/behaviours/GenerateRandom.beh
+++ b/supplementary/alica_turtlesim/etc/behaviours/GenerateRandom.beh
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 117244649116123551,
       "key": "min",
       "type": "double"
@@ -10,6 +11,7 @@
     {
       "access": "output",
       "comment": "",
+      "defaultValue": null,
       "id": 3318528501727248057,
       "key": "value",
       "type": "double"
@@ -17,6 +19,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 3464965572218487330,
       "key": "max",
       "type": "double"

--- a/supplementary/alica_turtlesim/etc/behaviours/GenerateRandom2.beh
+++ b/supplementary/alica_turtlesim/etc/behaviours/GenerateRandom2.beh
@@ -3,6 +3,7 @@
     {
       "access": "output",
       "comment": "",
+      "defaultValue": null,
       "id": 1661118062604805942,
       "key": "value",
       "type": "double"
@@ -10,6 +11,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 2831702563016616416,
       "key": "min",
       "type": "double"
@@ -17,6 +19,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 4515970455700756335,
       "key": "max",
       "type": "double"

--- a/supplementary/alica_turtlesim/etc/behaviours/GoTo.beh
+++ b/supplementary/alica_turtlesim/etc/behaviours/GoTo.beh
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 489836023935790753,
       "key": "goal_x",
       "type": "double"
@@ -10,6 +11,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 827646288361861518,
       "key": "goal_y",
       "type": "double"

--- a/supplementary/alica_turtlesim/etc/behaviours/Idle.beh
+++ b/supplementary/alica_turtlesim/etc/behaviours/Idle.beh
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "Time to idle in seconds",
+      "defaultValue": null,
       "id": 2537936451223247195,
       "key": "time",
       "type": "double"

--- a/supplementary/alica_turtlesim/etc/behaviours/Teleport.beh
+++ b/supplementary/alica_turtlesim/etc/behaviours/Teleport.beh
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 2065859497513016259,
       "key": "y",
       "type": "double"
@@ -10,6 +11,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 2249915898478593688,
       "key": "x",
       "type": "double"

--- a/supplementary/alica_turtlesim/etc/conditions/ConditionRepository.cnd
+++ b/supplementary/alica_turtlesim/etc/conditions/ConditionRepository.cnd
@@ -38,6 +38,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 1522671554895393021,
           "key": "left",
           "type": "std::string"
@@ -45,6 +46,7 @@
         {
           "access": "input",
           "comment": "",
+          "defaultValue": null,
           "id": 3837414941606102992,
           "key": "right",
           "type": "std::string"

--- a/supplementary/alica_turtlesim/etc/placeholders/WaitForMsg.plh
+++ b/supplementary/alica_turtlesim/etc/placeholders/WaitForMsg.plh
@@ -3,6 +3,7 @@
     {
       "access": "output",
       "comment": "The contents of the msg that was received on the topic",
+      "defaultValue": null,
       "id": 1670287826314001481,
       "key": "msg",
       "type": "std::string"
@@ -10,6 +11,7 @@
     {
       "access": "input",
       "comment": "The topic name on which to wait for the msg",
+      "defaultValue": null,
       "id": 3377017469681391113,
       "key": "topic",
       "type": "std::string"

--- a/supplementary/alica_turtlesim/etc/placeholders/WaitForTrigger.plh
+++ b/supplementary/alica_turtlesim/etc/placeholders/WaitForTrigger.plh
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "subscriber topic on which to listen for trigger msgs",
+      "defaultValue": null,
       "id": 2590992428289220704,
       "key": "topic",
       "type": "std::string"

--- a/supplementary/alica_turtlesim/etc/plans/CustomWorkflow.pml
+++ b/supplementary/alica_turtlesim/etc/plans/CustomWorkflow.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1373883389746082897,
       "key": "workflow",
       "type": "std::string"
@@ -10,6 +11,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 4268930889364842881,
       "key": "data",
       "type": "std::string"

--- a/supplementary/alica_turtlesim/etc/plans/CustomWorkflowTutorial.pml
+++ b/supplementary/alica_turtlesim/etc/plans/CustomWorkflowTutorial.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 3275358505487787998,
       "key": "task_msg",
       "type": "std::string"

--- a/supplementary/alica_turtlesim/etc/plans/MoveToWorkflow.pml
+++ b/supplementary/alica_turtlesim/etc/plans/MoveToWorkflow.pml
@@ -3,6 +3,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 610196170392400041,
       "key": "data",
       "type": "std::string"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1293324462022421085,
       "key": "target_x",
       "type": "double"
@@ -17,6 +19,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1302855491540810679,
       "key": "target_y",
       "type": "double"

--- a/supplementary/alica_turtlesim/etc/plans/RandomMoveTutorial.pml
+++ b/supplementary/alica_turtlesim/etc/plans/RandomMoveTutorial.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 268368693041806104,
       "key": "y",
       "type": "double"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 2295131000765240190,
       "key": "x",
       "type": "double"

--- a/supplementary/alica_turtlesim/etc/plans/TeleportToRandomPosition.pml
+++ b/supplementary/alica_turtlesim/etc/plans/TeleportToRandomPosition.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 598868303244083964,
       "key": "x",
       "type": "double"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 2712475924298828232,
       "key": "y",
       "type": "double"

--- a/supplementary/alica_turtlesim/etc/plans/TeleportToWorkflow.pml
+++ b/supplementary/alica_turtlesim/etc/plans/TeleportToWorkflow.pml
@@ -3,6 +3,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 1282199217470743347,
       "key": "target_x",
       "type": "double"
@@ -10,6 +11,7 @@
     {
       "access": "protected",
       "comment": "",
+      "defaultValue": null,
       "id": 2777554424664838944,
       "key": "target_y",
       "type": "double"
@@ -17,6 +19,7 @@
     {
       "access": "input",
       "comment": "",
+      "defaultValue": null,
       "id": 3936152552717061281,
       "key": "data",
       "type": "std::string"


### PR DESCRIPTION
- The master plan can specify if its keys are meant for the global blackboard using the inherit_blackboard flag in the .plc file. If true, the keys are populated to the global blackboard & the master plan simply inherits the global blackboard as its own. If false, the behaviour remains unchanged.
- Blackboard keys can now have default values

Design doc: https://gajanrapyutarobotics-my.sharepoint.com/:w:/g/personal/veeraj_khokale_rapyuta-robotics_com/EfxYaETn7ItNr5jGGRg4zjIBnXgWhDRmn5XFEhSS6Zr4EA?e=vkbIfr

- [x] Add unit test
- [x] Alica tests pass
- [x] Supplementary tests pass
- [x] Check turtlesim
- [x] Add support for default values
- [x] Add unit test for default values by regenerating etc folders using the new frontend