### PR TITLE
Fix precision error in ros clock sleep

### DIFF
--- a/supplementary/alica_ros1/alica_ros_proxy/src/clock/AlicaROSClock.cpp
+++ b/supplementary/alica_ros1/alica_ros_proxy/src/clock/AlicaROSClock.cpp
@@ -1,3 +1,4 @@
+#include "engine/AlicaClock.h"
 #include "ros/time.h"
 #include <clock/AlicaROSClock.h>
 
@@ -18,7 +19,7 @@ alica::AlicaTime AlicaROSClock::now() const
 
 void AlicaROSClock::sleep(const alica::AlicaTime& time) const
 {
-    ros::Duration(time.inSeconds()).sleep();
+    ros::Duration((double) time.inNanoseconds() / alica::AlicaTime::seconds(1).inNanoseconds()).sleep();
 }
 
 } // namespace alicaRosProxy


### PR DESCRIPTION
ros clock used AlicaTime::inSeconds() to convert
the duration of the sleep to seconds. However, this works out to 0 for any time interval < 1 sec. Since the sleep time is 33 ms in step engine, this can
cause problems. Futher, this rounding behaviour
is not intuitive for users of the clock in general

More details here: https://rapyuta-robotics.slack.com/archives/C01BRTPRCF5/p1729678490966409