### PR TITLE
No special handling of exceptions thrown from behaviours/plans

### DIFF
--- a/alica_engine/include/engine/RunnableObject.h
+++ b/alica_engine/include/engine/RunnableObject.h
@@ -64,7 +64,6 @@ public:
     void traceInitCall();
     void traceRunCall();
     void traceTerminateCall();
-    void traceException(const std::string& exceptionOriginMethod, const std::string& details);
     void finishTrace() { _trace.reset(); }
     const std::string& getName() const { return _name; }
 
@@ -126,8 +125,6 @@ protected:
     void setPlanBase(PlanBase* planBase);
     void setAlicaCommunication(const IAlicaCommunication* communication);
     void setAlicaTimerFactory(const IAlicaTimerFactory* timerFactory);
-
-    void handleException(const std::string& exceptionOriginMethod, std::exception_ptr eptr);
 
     TraceRunnableObject _runnableObjectTracer;
     const TeamManager* _teamManager{nullptr};

--- a/alica_engine/src/engine/BasicBehaviour.cpp
+++ b/alica_engine/src/engine/BasicBehaviour.cpp
@@ -50,20 +50,12 @@ AgentId BasicBehaviour::getOwnId() const
 
 void BasicBehaviour::doInit()
 {
-    try {
-        initialiseParameters();
-    } catch (...) {
-        handleException("initialise", std::current_exception());
-    }
+    initialiseParameters();
 }
 
 void BasicBehaviour::doRun()
 {
-    try {
-        run();
-    } catch (...) {
-        handleException("run", std::current_exception());
-    }
+    run();
 }
 
 std::string BasicBehaviour::resultToString(BehResult result)
@@ -86,11 +78,9 @@ void BasicBehaviour::doTerminate()
         Logging::logInfo(LOGNAME) << "Behaviour: " << getName() << ", result: " << resultStr;
         getTrace()->setTag("Result", resultStr);
     }
-    try {
-        onTermination();
-    } catch (...) {
-        handleException("terminate", std::current_exception());
-    }
+
+    onTermination();
+
     _behResult.store(BehResult::UNKNOWN);
 }
 

--- a/alica_engine/src/engine/BasicPlan.cpp
+++ b/alica_engine/src/engine/BasicPlan.cpp
@@ -27,29 +27,17 @@ BasicPlan::BasicPlan(PlanContext& context)
 
 void BasicPlan::doInit()
 {
-    try {
-        onInit();
-    } catch (const std::exception& e) {
-        handleException("initialise", std::current_exception());
-    }
+    onInit();
 }
 
 void BasicPlan::doRun()
 {
-    try {
-        run();
-    } catch (const std::exception& e) {
-        handleException("run", std::current_exception());
-    }
+    run();
 }
 
 void BasicPlan::doTerminate()
 {
-    try {
-        onTerminate();
-    } catch (const std::exception& e) {
-        handleException("terminate", std::current_exception());
-    }
+    onTerminate();
 }
 
 void BasicPlan::traceAssignmentChange(const std::string& assignedEntryPoint, double oldUtility, double newUtility, size_t numberOfAgents)

--- a/alica_engine/src/engine/RunnableObject.cpp
+++ b/alica_engine/src/engine/RunnableObject.cpp
@@ -139,29 +139,6 @@ const TeamManager& RunnableObject::getTeamManager() const
     return *_teamManager;
 }
 
-void TraceRunnableObject::traceException(const std::string& exceptionOriginMethod, const std::string& details)
-{
-    std::string msg = "Exception thrown from: " + getName() + "'s " + exceptionOriginMethod + " method";
-    if (!details.empty()) {
-        msg.append(", details: " + std::move(details));
-    }
-    Logging::logFatal(LOGNAME) << msg;
-}
-
-void RunnableObject::handleException(const std::string& exceptionOriginMethod, std::exception_ptr eptr)
-{
-    std::string details;
-    try {
-        std::rethrow_exception(eptr);
-    } catch (const std::exception& e) {
-        details = e.what();
-    } catch (...) {
-    }
-    _runnableObjectTracer.traceException(exceptionOriginMethod, details);
-    _runnableObjectTracer.finishTrace();
-    std::rethrow_exception(eptr);
-}
-
 // Tracing methods
 void TraceRunnableObject::setTracing(TracingType type, std::function<tracing::SpanStartOptions()> customTraceContextGetter)
 {


### PR DESCRIPTION
The current exception handling in both behaviours & plans (for user implemented code) traces the exception, logs it & then rethrows the exception. However, because the exception is caught & then rethrown the backtrace is lost making debugging impossible. It is better to get the backtrace than have a log/trace which often contains little to no information to actually fix the problem that caused the exception in the first place. Therefore, the exception handling is completely removed. If such handling is really required it can be implemented in the user code itself.

https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/83731